### PR TITLE
feat(oauth): implement server metadata discovery (AUTH-0004)

### DIFF
--- a/oauth/discovery.go
+++ b/oauth/discovery.go
@@ -1,0 +1,296 @@
+// Copyright © 2025-2026 Prabhjot Singh Sethi, All Rights reserved
+// Author: Prabhjot Singh Sethi <prabhjot.sethi@gmail.com>
+
+package oauth
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+
+	"github.com/go-core-stack/core/errors"
+)
+
+// maxMetadataBytes caps the size of a discovery document we are willing to read
+// into memory, so a misbehaving (or hostile) server cannot exhaust memory.
+const maxMetadataBytes = 1 << 20 // 1 MiB
+
+// httpDoFunc executes an HTTP request. *OAuthManager supplies m.httpDo (the
+// single outbound-HTTP chokepoint); unit tests supply a fake. Keeping discovery
+// parameterized on this func — and on serverCache below — lets the network and
+// caching paths be exercised with fakes, without a live MongoDB or server.
+type httpDoFunc func(req *http.Request) (*http.Response, error)
+
+// serverCache is the subset of the server table discovery needs. The concrete
+// *table.Table[ServerKey, ServerEntry] satisfies it; tests substitute a fake.
+type serverCache interface {
+	Find(ctx context.Context, key *ServerKey) (*ServerEntry, error)
+	Locate(ctx context.Context, key *ServerKey, entry *ServerEntry) error
+}
+
+// protectedResourceMetadata is the RFC 9728 protected-resource document. JSON
+// is parsed defensively: optional fields are simply absent when omitted.
+type protectedResourceMetadata struct {
+	Resource             string   `json:"resource"`
+	AuthorizationServers []string `json:"authorization_servers"`
+	ScopesSupported      []string `json:"scopes_supported"`
+}
+
+// authServerMetadata is the RFC 8414 authorization-server document, which is a
+// superset-compatible shape with the OIDC openid-configuration fallback.
+type authServerMetadata struct {
+	Issuer                string   `json:"issuer"`
+	AuthorizationEndpoint string   `json:"authorization_endpoint"`
+	TokenEndpoint         string   `json:"token_endpoint"`
+	RevocationEndpoint    string   `json:"revocation_endpoint"`
+	RegistrationEndpoint  string   `json:"registration_endpoint"`
+	GrantTypesSupported   []string `json:"grant_types_supported"`
+}
+
+// DiscoverServer returns the OAuth/OIDC metadata for a remote server, fetching
+// and caching it on a miss. On a cache hit it returns the stored entry without
+// any network call. Discovery is layered: RFC 9728 protected-resource metadata
+// identifies the authorization server, whose RFC 8414 metadata (with an OIDC
+// openid-configuration fallback) yields the authorization/token/revocation/
+// registration endpoints. The result is upserted into the server table keyed by
+// the normalized server URL.
+func (m *OAuthManager) DiscoverServer(ctx context.Context, serverURL string) (*ServerEntry, error) {
+	return discoverServer(ctx, m.httpDo, m.serverTable, serverURL)
+}
+
+// RefreshServerMetadata forces a fresh discovery, ignoring any cached entry, and
+// upserts the result.
+func (m *OAuthManager) RefreshServerMetadata(ctx context.Context, serverURL string) (*ServerEntry, error) {
+	return refreshServerMetadata(ctx, m.httpDo, m.serverTable, serverURL)
+}
+
+// GetCachedServer returns the cached metadata for a server, or (nil, nil) if it
+// has not been discovered yet. It never performs a network call.
+func (m *OAuthManager) GetCachedServer(ctx context.Context, serverURL string) (*ServerEntry, error) {
+	return getCachedServer(ctx, m.serverTable, serverURL)
+}
+
+// discoverServer implements DiscoverServer against the serverCache/httpDoFunc
+// interfaces so it is unit-testable with fakes.
+func discoverServer(ctx context.Context, do httpDoFunc, cache serverCache, serverURL string) (*ServerEntry, error) {
+	normalized := normalizeServerURL(serverURL)
+	if normalized == "" {
+		return nil, errors.Wrap(errors.InvalidArgument, "oauth: serverURL must not be empty")
+	}
+
+	entry, err := cache.Find(ctx, &ServerKey{ServerURL: normalized})
+	if err == nil {
+		return entry, nil
+	}
+	if !errors.IsNotFound(err) {
+		return nil, err
+	}
+
+	return discoverAndCache(ctx, do, cache, normalized)
+}
+
+// refreshServerMetadata implements RefreshServerMetadata (skip cache, fetch
+// fresh, upsert).
+func refreshServerMetadata(ctx context.Context, do httpDoFunc, cache serverCache, serverURL string) (*ServerEntry, error) {
+	normalized := normalizeServerURL(serverURL)
+	if normalized == "" {
+		return nil, errors.Wrap(errors.InvalidArgument, "oauth: serverURL must not be empty")
+	}
+	return discoverAndCache(ctx, do, cache, normalized)
+}
+
+// getCachedServer implements GetCachedServer's read-only lookup, mapping a cache
+// miss to (nil, nil).
+func getCachedServer(ctx context.Context, cache serverCache, serverURL string) (*ServerEntry, error) {
+	normalized := normalizeServerURL(serverURL)
+	if normalized == "" {
+		return nil, errors.Wrap(errors.InvalidArgument, "oauth: serverURL must not be empty")
+	}
+	entry, err := cache.Find(ctx, &ServerKey{ServerURL: normalized})
+	if err != nil {
+		if errors.IsNotFound(err) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	return entry, nil
+}
+
+// discoverAndCache performs the full discovery chain for an already-normalized
+// server URL and upserts the resulting entry into the cache.
+func discoverAndCache(ctx context.Context, do httpDoFunc, cache serverCache, normalized string) (*ServerEntry, error) {
+	// RFC 9728: protected-resource metadata names the authorization server(s).
+	prURL, err := wellKnownInsertURL(normalized, WellKnownProtectedResource)
+	if err != nil {
+		return nil, err
+	}
+	var prm protectedResourceMetadata
+	if err := getJSON(ctx, do, prURL, &prm); err != nil {
+		return nil, errors.Wrapf(errors.GetErrCode(err),
+			"oauth: failed to fetch protected-resource metadata for %s: %s", normalized, err)
+	}
+	if len(prm.AuthorizationServers) == 0 {
+		return nil, errors.Wrapf(errors.InvalidArgument,
+			"oauth: protected-resource metadata for %s has no authorization_servers", normalized)
+	}
+	asURL := normalizeServerURL(prm.AuthorizationServers[0])
+
+	// RFC 8414 authorization-server metadata, with OIDC discovery fallback.
+	// fetchAuthServerMetadata guarantees a usable token/authorization endpoint
+	// or a clear error, so no further endpoint check is needed here.
+	asMeta, err := fetchAuthServerMetadata(ctx, do, asURL)
+	if err != nil {
+		return nil, err
+	}
+
+	entry := &ServerEntry{
+		Resource:              prm.Resource,
+		AuthorizationServers:  prm.AuthorizationServers,
+		ScopesSupported:       prm.ScopesSupported,
+		Issuer:                asMeta.Issuer,
+		AuthorizationEndpoint: asMeta.AuthorizationEndpoint,
+		TokenEndpoint:         asMeta.TokenEndpoint,
+		RevocationEndpoint:    asMeta.RevocationEndpoint,
+		RegistrationEndpoint:  asMeta.RegistrationEndpoint,
+		GrantTypesSupported:   asMeta.GrantTypesSupported,
+		DiscoveredAt:          time.Now().Unix(),
+	}
+	if err := cache.Locate(ctx, &ServerKey{ServerURL: normalized}, entry); err != nil {
+		return nil, errors.Wrapf(errors.GetErrCode(err),
+			"oauth: failed to cache server metadata for %s: %s", normalized, err)
+	}
+	return entry, nil
+}
+
+// fetchAuthServerMetadata tries RFC 8414 first and falls back to OIDC
+// openid-configuration. The fallback is taken not only when the RFC 8414 fetch
+// fails but also when it succeeds yet yields no usable token/authorization
+// endpoint (a present-but-incomplete 8414 document), so a server that only
+// publishes complete metadata at the OIDC endpoint still discovers.
+func fetchAuthServerMetadata(ctx context.Context, do httpDoFunc, asURL string) (*authServerMetadata, error) {
+	rfcURL, err := wellKnownInsertURL(asURL, WellKnownAuthorizationServer)
+	if err != nil {
+		return nil, err
+	}
+	var meta authServerMetadata
+	rfcErr := getJSON(ctx, do, rfcURL, &meta)
+	if rfcErr == nil && metadataHasEndpoint(&meta) {
+		return &meta, nil
+	}
+
+	// Fall back to OIDC discovery. Reset to avoid retaining any partial parse.
+	oidcURL, err := wellKnownAppendURL(asURL, WellKnownOpenIDConfiguration)
+	if err != nil {
+		return nil, err
+	}
+	var oidc authServerMetadata
+	oidcErr := getJSON(ctx, do, oidcURL, &oidc)
+	if oidcErr == nil && metadataHasEndpoint(&oidc) {
+		return &oidc, nil
+	}
+
+	return nil, errors.Wrapf(errors.InvalidArgument,
+		"oauth: no usable authorization-server metadata for %s (RFC 8414: %s; OIDC: %s)",
+		asURL, metadataFailureReason(rfcErr), metadataFailureReason(oidcErr))
+}
+
+// metadataHasEndpoint reports whether a discovery document carries at least one
+// of the endpoints the rest of the library needs.
+func metadataHasEndpoint(m *authServerMetadata) bool {
+	return m.AuthorizationEndpoint != "" || m.TokenEndpoint != ""
+}
+
+// metadataFailureReason renders why an authorization-server fetch did not yield
+// usable metadata: the fetch error if any, otherwise the document was reachable
+// but incomplete.
+func metadataFailureReason(err error) string {
+	if err != nil {
+		return err.Error()
+	}
+	return "no token or authorization endpoint"
+}
+
+// getJSON performs a GET and decodes a JSON body into out, wrapping network,
+// HTTP-status, and parse failures with core/errors codes.
+func getJSON(ctx context.Context, do httpDoFunc, url string, out any) error {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return errors.Wrapf(errors.InvalidArgument, "oauth: failed to build request for %s: %s", url, err)
+	}
+	req.Header.Set("Accept", "application/json")
+
+	resp, err := do(req)
+	if err != nil {
+		return errors.Wrapf(errors.Unknown, "oauth: request to %s failed: %s", url, err)
+	}
+	// Wrap the body in a single LimitReader so reads and the deferred drain share
+	// one maxMetadataBytes budget: an oversized or hostile body can never cause
+	// more than maxMetadataBytes total to be read.
+	limited := io.LimitReader(resp.Body, maxMetadataBytes)
+	// Drain (bounded) before closing so the underlying connection can be reused
+	// for the next discovery request, including on the non-2xx and size-limit
+	// paths where the body is otherwise left partially read.
+	defer func() {
+		_, _ = io.Copy(io.Discard, limited)
+		_ = resp.Body.Close()
+	}()
+
+	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
+		return errors.Wrapf(errors.Unknown, "oauth: %s returned HTTP status %d", url, resp.StatusCode)
+	}
+
+	body, err := io.ReadAll(limited)
+	if err != nil {
+		return errors.Wrapf(errors.Unknown, "oauth: failed to read response from %s: %s", url, err)
+	}
+	if err := json.Unmarshal(body, out); err != nil {
+		return errors.Wrapf(errors.InvalidArgument, "oauth: failed to parse JSON from %s: %s", url, err)
+	}
+	return nil
+}
+
+// normalizeServerURL trims surrounding whitespace and any trailing slash so the
+// same logical server maps to one cache key and one set of well-known URLs.
+func normalizeServerURL(serverURL string) string {
+	return strings.TrimRight(strings.TrimSpace(serverURL), "/")
+}
+
+// wellKnownInsertURL builds an RFC 9728 / RFC 8414 well-known URL by inserting
+// the well-known segment between the host and any path component of base, as the
+// RFCs require for identifiers that carry a path:
+//
+//	https://h           + /.well-known/x -> https://h/.well-known/x
+//	https://h/tenant    + /.well-known/x -> https://h/.well-known/x/tenant
+//
+// For the common bare-origin case (no path) this is identical to a suffix
+// append. Query and fragment are dropped (discovery identifiers carry neither).
+func wellKnownInsertURL(base, segment string) (string, error) {
+	u, err := url.Parse(base)
+	if err != nil {
+		return "", errors.Wrapf(errors.InvalidArgument, "oauth: invalid server URL %q: %s", base, err)
+	}
+	u.Path = segment + strings.TrimSuffix(u.Path, "/")
+	u.RawQuery = ""
+	u.Fragment = ""
+	return u.String(), nil
+}
+
+// wellKnownAppendURL builds an OIDC discovery URL by appending the well-known
+// segment after any path component of base, per OpenID Connect Discovery §4:
+//
+//	https://h/tenant + /.well-known/openid-configuration
+//	  -> https://h/tenant/.well-known/openid-configuration
+func wellKnownAppendURL(base, segment string) (string, error) {
+	u, err := url.Parse(base)
+	if err != nil {
+		return "", errors.Wrapf(errors.InvalidArgument, "oauth: invalid server URL %q: %s", base, err)
+	}
+	u.Path = strings.TrimSuffix(u.Path, "/") + segment
+	u.RawQuery = ""
+	u.Fragment = ""
+	return u.String(), nil
+}

--- a/oauth/discovery_test.go
+++ b/oauth/discovery_test.go
@@ -1,0 +1,384 @@
+// Copyright © 2025-2026 Prabhjot Singh Sethi, All Rights reserved
+// Author: Prabhjot Singh Sethi <prabhjot.sethi@gmail.com>
+
+package oauth
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/go-core-stack/core/errors"
+)
+
+// --- fakes ---
+
+// fakeServerCache is an in-memory serverCache that records access counts so
+// tests can assert cache-hit/miss and read-only behavior.
+type fakeServerCache struct {
+	entries   map[string]*ServerEntry
+	findCalls int
+	locates   int
+}
+
+func newFakeServerCache() *fakeServerCache {
+	return &fakeServerCache{entries: map[string]*ServerEntry{}}
+}
+
+func (c *fakeServerCache) Find(_ context.Context, key *ServerKey) (*ServerEntry, error) {
+	c.findCalls++
+	e, ok := c.entries[key.ServerURL]
+	if !ok {
+		return nil, errors.Wrapf(errors.NotFound, "no entry for %s", key.ServerURL)
+	}
+	return e, nil
+}
+
+func (c *fakeServerCache) Locate(_ context.Context, key *ServerKey, entry *ServerEntry) error {
+	c.locates++
+	c.entries[key.ServerURL] = entry
+	return nil
+}
+
+// jsonResponse builds a 200 JSON HTTP response.
+func jsonResponse(body string) *http.Response {
+	return &http.Response{
+		StatusCode: http.StatusOK,
+		Body:       io.NopCloser(strings.NewReader(body)),
+		Header:     http.Header{"Content-Type": []string{"application/json"}},
+	}
+}
+
+// statusResponse builds an empty response with the given status code.
+func statusResponse(code int) *http.Response {
+	return &http.Response{
+		StatusCode: code,
+		Body:       io.NopCloser(strings.NewReader("")),
+		Header:     http.Header{},
+	}
+}
+
+// routingDoer returns an httpDoFunc that serves responses keyed by the request
+// path suffix, recording each path it was asked for.
+func routingDoer(t *testing.T, routes map[string]*http.Response, calls *[]string) httpDoFunc {
+	t.Helper()
+	return func(req *http.Request) (*http.Response, error) {
+		*calls = append(*calls, req.URL.Path)
+		if resp, ok := routes[req.URL.Path]; ok {
+			return resp, nil
+		}
+		t.Fatalf("unexpected request to %s", req.URL.String())
+		return nil, nil
+	}
+}
+
+const (
+	prDoc = `{
+		"resource": "https://api.example.com",
+		"authorization_servers": ["https://as.example.com"],
+		"scopes_supported": ["read", "write"]
+	}`
+	asDoc = `{
+		"issuer": "https://as.example.com",
+		"authorization_endpoint": "https://as.example.com/authorize",
+		"token_endpoint": "https://as.example.com/token",
+		"revocation_endpoint": "https://as.example.com/revoke",
+		"registration_endpoint": "https://as.example.com/register",
+		"grant_types_supported": ["authorization_code", "refresh_token"]
+	}`
+	oidcDoc = `{
+		"issuer": "https://as.example.com",
+		"authorization_endpoint": "https://as.example.com/oidc/authorize",
+		"token_endpoint": "https://as.example.com/oidc/token"
+	}`
+)
+
+// --- tests ---
+
+func TestDiscoverAndCache_HappyPath(t *testing.T) {
+	var calls []string
+	do := routingDoer(t, map[string]*http.Response{
+		WellKnownProtectedResource:   jsonResponse(prDoc),
+		WellKnownAuthorizationServer: jsonResponse(asDoc),
+	}, &calls)
+	cache := newFakeServerCache()
+
+	entry, err := discoverAndCache(context.Background(), do, cache, "https://api.example.com")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if entry.AuthorizationEndpoint != "https://as.example.com/authorize" {
+		t.Errorf("authorization endpoint = %q", entry.AuthorizationEndpoint)
+	}
+	if entry.TokenEndpoint != "https://as.example.com/token" {
+		t.Errorf("token endpoint = %q", entry.TokenEndpoint)
+	}
+	if entry.RegistrationEndpoint != "https://as.example.com/register" {
+		t.Errorf("registration endpoint = %q", entry.RegistrationEndpoint)
+	}
+	if entry.DiscoveredAt == 0 {
+		t.Error("DiscoveredAt should be set")
+	}
+	if len(entry.AuthorizationServers) != 1 || entry.AuthorizationServers[0] != "https://as.example.com" {
+		t.Errorf("authorization servers = %v", entry.AuthorizationServers)
+	}
+	if cache.locates != 1 {
+		t.Errorf("expected 1 upsert, got %d", cache.locates)
+	}
+	if got := cache.entries["https://api.example.com"]; got == nil {
+		t.Error("entry not cached under normalized key")
+	}
+}
+
+func TestDiscoverAndCache_MissingAuthorizationServers(t *testing.T) {
+	var calls []string
+	do := routingDoer(t, map[string]*http.Response{
+		WellKnownProtectedResource: jsonResponse(`{"resource":"https://api.example.com"}`),
+	}, &calls)
+	cache := newFakeServerCache()
+
+	_, err := discoverAndCache(context.Background(), do, cache, "https://api.example.com")
+	if err == nil {
+		t.Fatal("expected error for missing authorization_servers")
+	}
+	if !errors.IsInvalidArgument(err) {
+		t.Errorf("expected InvalidArgument, got %v", err)
+	}
+	if cache.locates != 0 {
+		t.Error("nothing should be cached on failure")
+	}
+}
+
+func TestDiscoverAndCache_OIDCFallback(t *testing.T) {
+	var calls []string
+	do := routingDoer(t, map[string]*http.Response{
+		WellKnownProtectedResource:   jsonResponse(prDoc),
+		WellKnownAuthorizationServer: statusResponse(http.StatusNotFound), // RFC 8414 unavailable
+		WellKnownOpenIDConfiguration: jsonResponse(oidcDoc),
+	}, &calls)
+	cache := newFakeServerCache()
+
+	entry, err := discoverAndCache(context.Background(), do, cache, "https://api.example.com")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if entry.TokenEndpoint != "https://as.example.com/oidc/token" {
+		t.Errorf("expected OIDC token endpoint, got %q", entry.TokenEndpoint)
+	}
+	// confirm the fallback path was actually exercised
+	var sawOIDC bool
+	for _, p := range calls {
+		if p == WellKnownOpenIDConfiguration {
+			sawOIDC = true
+		}
+	}
+	if !sawOIDC {
+		t.Errorf("OIDC fallback not attempted; calls=%v", calls)
+	}
+}
+
+func TestDiscoverAndCache_NoEndpoints(t *testing.T) {
+	var calls []string
+	// RFC 8414 responds 200 but without endpoints, and OIDC is unavailable: with
+	// no usable metadata from either source, discovery must fail.
+	do := routingDoer(t, map[string]*http.Response{
+		WellKnownProtectedResource:   jsonResponse(prDoc),
+		WellKnownAuthorizationServer: jsonResponse(`{"issuer":"https://as.example.com"}`),
+		WellKnownOpenIDConfiguration: statusResponse(http.StatusNotFound),
+	}, &calls)
+	cache := newFakeServerCache()
+
+	_, err := discoverAndCache(context.Background(), do, cache, "https://api.example.com")
+	if err == nil {
+		t.Fatal("expected error when no token/authorization endpoint is discovered")
+	}
+	if !errors.IsInvalidArgument(err) {
+		t.Errorf("expected InvalidArgument, got %v", err)
+	}
+	if cache.locates != 0 {
+		t.Error("nothing should be cached on failure")
+	}
+}
+
+// An RFC 8414 document that is reachable (HTTP 200) but missing endpoints must
+// still trigger the OIDC fallback, which here supplies the usable metadata.
+func TestDiscoverAndCache_OIDCFallbackOnIncomplete8414(t *testing.T) {
+	var calls []string
+	do := routingDoer(t, map[string]*http.Response{
+		WellKnownProtectedResource:   jsonResponse(prDoc),
+		WellKnownAuthorizationServer: jsonResponse(`{"issuer":"https://as.example.com"}`), // 200 but no endpoints
+		WellKnownOpenIDConfiguration: jsonResponse(oidcDoc),
+	}, &calls)
+	cache := newFakeServerCache()
+
+	entry, err := discoverAndCache(context.Background(), do, cache, "https://api.example.com")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if entry.TokenEndpoint != "https://as.example.com/oidc/token" {
+		t.Errorf("expected OIDC token endpoint, got %q", entry.TokenEndpoint)
+	}
+}
+
+func TestDiscoverAndCache_BothASDocsFail(t *testing.T) {
+	var calls []string
+	do := routingDoer(t, map[string]*http.Response{
+		WellKnownProtectedResource:   jsonResponse(prDoc),
+		WellKnownAuthorizationServer: statusResponse(http.StatusNotFound),
+		WellKnownOpenIDConfiguration: statusResponse(http.StatusNotFound),
+	}, &calls)
+	cache := newFakeServerCache()
+
+	if _, err := discoverAndCache(context.Background(), do, cache, "https://api.example.com"); err == nil {
+		t.Fatal("expected error when both RFC 8414 and OIDC discovery fail")
+	}
+}
+
+func TestDiscoverServer_CacheHitNoNetwork(t *testing.T) {
+	cache := newFakeServerCache()
+	cache.entries["https://api.example.com"] = &ServerEntry{TokenEndpoint: "https://as.example.com/token"}
+
+	// A do func that fails the test if invoked proves the cache hit short-circuits
+	// the network. The trailing slash also exercises key normalization on hit.
+	do := func(req *http.Request) (*http.Response, error) {
+		t.Fatalf("network call made on cache hit: %s", req.URL)
+		return nil, nil
+	}
+
+	entry, err := discoverServer(context.Background(), do, cache, "https://api.example.com/")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if entry.TokenEndpoint != "https://as.example.com/token" {
+		t.Errorf("expected cached entry, got %v", entry)
+	}
+	if cache.locates != 0 {
+		t.Error("cache hit must not upsert")
+	}
+}
+
+func TestRefreshServerMetadata_SkipsCache(t *testing.T) {
+	var calls []string
+	do := routingDoer(t, map[string]*http.Response{
+		WellKnownProtectedResource:   jsonResponse(prDoc),
+		WellKnownAuthorizationServer: jsonResponse(asDoc),
+	}, &calls)
+	cache := newFakeServerCache()
+	// Pre-seed a stale entry; refresh must ignore it and re-fetch over the network.
+	cache.entries["https://api.example.com"] = &ServerEntry{TokenEndpoint: "stale"}
+
+	entry, err := refreshServerMetadata(context.Background(), do, cache, "https://api.example.com")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if entry.TokenEndpoint != "https://as.example.com/token" {
+		t.Errorf("refresh did not re-fetch; token endpoint = %q", entry.TokenEndpoint)
+	}
+	if len(calls) == 0 {
+		t.Error("refresh must perform network calls even when cached")
+	}
+	if cache.locates != 1 {
+		t.Errorf("refresh must upsert fresh metadata; locates = %d", cache.locates)
+	}
+}
+
+func TestGetCachedServer_HitAndMiss(t *testing.T) {
+	cache := newFakeServerCache()
+
+	// miss → (nil, nil), no upsert, read-only
+	got, err := getCachedServer(context.Background(), cache, "https://api.example.com/")
+	if err != nil {
+		t.Fatalf("unexpected error on miss: %v", err)
+	}
+	if got != nil {
+		t.Errorf("expected nil on miss, got %v", got)
+	}
+
+	// hit (note normalization: stored under the no-trailing-slash key)
+	cache.entries["https://api.example.com"] = &ServerEntry{TokenEndpoint: "https://as.example.com/token"}
+	got, err = getCachedServer(context.Background(), cache, "https://api.example.com")
+	if err != nil {
+		t.Fatalf("unexpected error on hit: %v", err)
+	}
+	if got == nil || got.TokenEndpoint != "https://as.example.com/token" {
+		t.Errorf("expected cached entry, got %v", got)
+	}
+	if cache.locates != 0 {
+		t.Error("GetCachedServer must be read-only")
+	}
+}
+
+func TestNormalizeServerURL(t *testing.T) {
+	cases := map[string]string{
+		"https://api.example.com/":    "https://api.example.com",
+		"https://api.example.com":     "https://api.example.com",
+		"  https://api.example.com/ ": "https://api.example.com",
+		"https://api.example.com///":  "https://api.example.com",
+		"":                            "",
+	}
+	for in, want := range cases {
+		if got := normalizeServerURL(in); got != want {
+			t.Errorf("normalizeServerURL(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+func TestWellKnownInsertURL(t *testing.T) {
+	cases := []struct{ base, want string }{
+		{"https://h", "https://h/.well-known/oauth-protected-resource"},
+		{"https://h/tenant", "https://h/.well-known/oauth-protected-resource/tenant"},
+		{"https://h/a/b", "https://h/.well-known/oauth-protected-resource/a/b"},
+	}
+	for _, c := range cases {
+		got, err := wellKnownInsertURL(c.base, WellKnownProtectedResource)
+		if err != nil {
+			t.Fatalf("wellKnownInsertURL(%q): %v", c.base, err)
+		}
+		if got != c.want {
+			t.Errorf("wellKnownInsertURL(%q) = %q, want %q", c.base, got, c.want)
+		}
+	}
+}
+
+func TestWellKnownAppendURL(t *testing.T) {
+	cases := []struct{ base, want string }{
+		{"https://h", "https://h/.well-known/openid-configuration"},
+		{"https://h/tenant", "https://h/tenant/.well-known/openid-configuration"},
+	}
+	for _, c := range cases {
+		got, err := wellKnownAppendURL(c.base, WellKnownOpenIDConfiguration)
+		if err != nil {
+			t.Fatalf("wellKnownAppendURL(%q): %v", c.base, err)
+		}
+		if got != c.want {
+			t.Errorf("wellKnownAppendURL(%q) = %q, want %q", c.base, got, c.want)
+		}
+	}
+}
+
+// Resource and authorization-server identifiers that carry a path must have the
+// well-known segment inserted after the host (RFC 9728 / RFC 8414), not simply
+// appended to the end of the path.
+func TestDiscoverAndCache_PathBearingURLs(t *testing.T) {
+	var calls []string
+	do := routingDoer(t, map[string]*http.Response{
+		"/.well-known/oauth-protected-resource/mcp": jsonResponse(
+			`{"resource":"https://api.example.com/mcp","authorization_servers":["https://as.example.com/tenant1"]}`),
+		"/.well-known/oauth-authorization-server/tenant1": jsonResponse(asDoc),
+	}, &calls)
+	cache := newFakeServerCache()
+
+	entry, err := discoverAndCache(context.Background(), do, cache, "https://api.example.com/mcp")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if entry.TokenEndpoint != "https://as.example.com/token" {
+		t.Errorf("token endpoint = %q", entry.TokenEndpoint)
+	}
+	// cached under the normalized path-bearing resource URL
+	if cache.entries["https://api.example.com/mcp"] == nil {
+		t.Errorf("entry not cached under path-bearing key; keys=%v", cache.entries)
+	}
+}

--- a/oauth/manager.go
+++ b/oauth/manager.go
@@ -155,8 +155,6 @@ func (m *OAuthManager) initManagerEncryptor(cfg OAuthConfig) (utils.IOEncryptor,
 // the single chokepoint for outbound HTTP so timeout/retry policy can evolve in
 // one place; discovery, registration, and token exchange (AUTH-0004..0007) use
 // it.
-//
-//nolint:unused // consumed by AUTH-0004..0007
 func (m *OAuthManager) httpDo(req *http.Request) (*http.Response, error) {
 	return m.httpClient.Do(req)
 }


### PR DESCRIPTION
## Summary

Implements **AUTH-0004** (Commit 3 of the OAuth client library plan): layered OAuth/OIDC server metadata discovery and caching on `OAuthManager`. Other flows (registration, authorization, tokens) depend on the discovered authorization/token/revocation/registration endpoints.

Depends on AUTH-0003 (manager init, tables, locks, reconcilers).

## What's included

- **`oauth/discovery.go`** — three methods on `*OAuthManager`:
  - `DiscoverServer(ctx, serverURL)` — cache-first; on a miss runs the discovery chain and upserts the result. Returns the cached entry **without any network call** on a hit.
  - `RefreshServerMetadata(ctx, serverURL)` — forces fresh re-discovery (skips cache), upserts.
  - `GetCachedServer(ctx, serverURL)` — read-only; returns `(nil, nil)` on a miss, never hits the network.
- **Discovery chain**: RFC 9728 protected-resource metadata → `authorization_servers[0]` → RFC 8414 authorization-server metadata, with an OIDC `openid-configuration` fallback → upsert into the `servers` table keyed by the normalized server URL.
- Results wired through the manager's `httpDo` chokepoint and the `serverTable` initialized in `NewOAuthManager`.

## Notable decisions

- **RFC-correct well-known URLs**: the well-known segment is inserted between host and path for RFC 9728/8414 (`https://h/mcp` → `https://h/.well-known/oauth-protected-resource/mcp`) and appended for OIDC discovery (per OIDC Discovery §4). Bare-origin servers are unchanged.
- **OIDC fallback on incomplete 8414**: the fallback triggers not only when the RFC 8414 fetch errors, but also when it returns HTTP 200 yet yields no usable token/authorization endpoint.
- **Defensive HTTP**: `serverURL` normalized (trim whitespace + trailing slash) for keys and URL building; response bodies size-capped (1 MiB) and drained before close for connection reuse; network/parse/status failures wrapped with `core/errors` codes.
- Single-authorization-server selection (`[0]`) and lock-serialized discovery are intentionally out of scope here (the latter is reserved for AUTH-0005).

## Testing

`go build ./...`, `go vet ./...`, `go test -race ./oauth/...`, and `golangci-lint run` all pass. Discovery is unit-tested with mocked HTTP and a fake cache: happy path, missing `authorization_servers`, RFC 8414 → OIDC fallback (both transport-error and incomplete-document cases), no-endpoints error, cache hit (no network), refresh-skips-cache, read-only `GetCachedServer`, URL normalization, and RFC well-known URL construction for path-bearing identifiers.

Refs: AUTH-0004