### PR TITLE
feat(oauth): implement dynamic client registration (AUTH-0005)

### DIFF
--- a/oauth/registration.go
+++ b/oauth/registration.go
@@ -1,0 +1,339 @@
+// Copyright © 2025-2026 Prabhjot Singh Sethi, All Rights reserved
+// Author: Prabhjot Singh Sethi <prabhjot.sethi@gmail.com>
+
+package oauth
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/go-core-stack/core/errors"
+	coresync "github.com/go-core-stack/core/sync"
+)
+
+// ClientType / RegistrationType values persisted on ClientEntry.
+const (
+	clientTypePublic        = "public"
+	registrationTypeDynamic = "dynamic"
+	responseTypeCode        = "code"
+)
+
+// errStaticRegistrationUnimplemented is returned by RegisterStaticClient. Static
+// registration is interface-only in this version (see OPEN-POINTS #2); the
+// method exists so confidential/static support can land later without an API
+// change. core/errors has no dedicated "unimplemented" code, so — mirroring the
+// errRefreshNotImplemented sentinel used by the token reconciler — this is a
+// sentinel matchable with errors.Is.
+var errStaticRegistrationUnimplemented = errors.New("oauth: static client registration is not implemented (see OPEN-POINTS #2)")
+
+// clientStore is the subset of the client table that registration needs. The
+// concrete *table.Table[ClientKey, ClientEntry] satisfies it; tests substitute a
+// fake so the cache, lock, and HTTP paths are exercised without a live MongoDB.
+type clientStore interface {
+	Find(ctx context.Context, key *ClientKey) (*ClientEntry, error)
+	Insert(ctx context.Context, key *ClientKey, entry *ClientEntry) error
+	DeleteKey(ctx context.Context, key *ClientKey) error
+}
+
+// registrationLocker is the subset of the registration lock table registration
+// needs. *coresync.LockTable[RegistrationLockKey] satisfies it.
+type registrationLocker interface {
+	TryAcquire(ctx context.Context, key *RegistrationLockKey) (coresync.Lock, error)
+}
+
+// discoverFunc resolves (and caches) server metadata for a server URL.
+// *OAuthManager supplies m.DiscoverServer; tests supply a fake.
+type discoverFunc func(ctx context.Context, serverURL string) (*ServerEntry, error)
+
+// clientRegistrationRequest is the RFC 7591 dynamic client registration request
+// body for a public client.
+type clientRegistrationRequest struct {
+	ClientName              string   `json:"client_name,omitempty"`
+	RedirectURIs            []string `json:"redirect_uris,omitempty"`
+	GrantTypes              []string `json:"grant_types,omitempty"`
+	ResponseTypes           []string `json:"response_types,omitempty"`
+	TokenEndpointAuthMethod string   `json:"token_endpoint_auth_method,omitempty"`
+	Scope                   string   `json:"scope,omitempty"`
+}
+
+// clientRegistrationResponse is the RFC 7591 §3.2.1 registration response. Parsed
+// defensively: optional fields are simply absent when omitted by the server.
+type clientRegistrationResponse struct {
+	ClientID                string   `json:"client_id"`
+	ClientSecret            string   `json:"client_secret"`
+	ClientSecretExpiresAt   int64    `json:"client_secret_expires_at"`
+	RegistrationClientURI   string   `json:"registration_client_uri"`
+	RegistrationAccessToken string   `json:"registration_access_token"`
+	RedirectURIs            []string `json:"redirect_uris"`
+	GrantTypes              []string `json:"grant_types"`
+	Scope                   string   `json:"scope"`
+}
+
+// RegisterDynamicClient registers (RFC 7591) a public OAuth client for a remote
+// server and persists it, returning the existing client on a cache hit so the
+// call is idempotent. Registration is serialized per server by a distributed
+// lock, with a double-check inside the lock so two replicas that both miss the
+// initial cache check register exactly once.
+func (m *OAuthManager) RegisterDynamicClient(ctx context.Context, opts RegisterClientOptions) (*ClientEntry, error) {
+	return registerDynamicClient(ctx, m.httpDo, m.clientTable, m.registrationLocks, m.DiscoverServer, m.config, opts)
+}
+
+// ReRegisterClient deletes any stored client for the server, then runs the
+// dynamic registration path fresh. Used when an existing client may have expired
+// or the server returned invalid_client.
+func (m *OAuthManager) ReRegisterClient(ctx context.Context, opts RegisterClientOptions) (*ClientEntry, error) {
+	return reRegisterClient(ctx, m.httpDo, m.clientTable, m.registrationLocks, m.DiscoverServer, m.config, opts)
+}
+
+// GetClient returns the stored client for a server, or (nil, nil) if none has
+// been registered yet. It never performs a network call.
+func (m *OAuthManager) GetClient(ctx context.Context, serverURL string) (*ClientEntry, error) {
+	return getClient(ctx, m.clientTable, serverURL)
+}
+
+// RegisterStaticClient is the entry point for statically (pre-)provisioned
+// clients. It is interface-only in this version and always returns
+// errStaticRegistrationUnimplemented (see OPEN-POINTS #2).
+func (m *OAuthManager) RegisterStaticClient(_ context.Context, _ string, _ ClientEntry) error {
+	return errStaticRegistrationUnimplemented
+}
+
+// registerDynamicClient implements RegisterDynamicClient against the
+// clientStore/registrationLocker/discoverFunc/httpDoFunc interfaces so it is
+// unit-testable with fakes.
+func registerDynamicClient(ctx context.Context, do httpDoFunc, clients clientStore, locks registrationLocker, discover discoverFunc, cfg OAuthConfig, opts RegisterClientOptions) (*ClientEntry, error) {
+	normalized := normalizeServerURL(opts.ServerURL)
+	if normalized == "" {
+		return nil, errors.Wrap(errors.InvalidArgument, "oauth: serverURL must not be empty")
+	}
+	merged := mergeRegisterOptions(cfg, opts)
+
+	// Idempotent fast path: return an already-registered client without taking
+	// the lock or touching the network.
+	existing, err := findClient(ctx, clients, normalized)
+	if err != nil {
+		return nil, err
+	}
+	if existing != nil {
+		return existing, nil
+	}
+
+	// Serialize registration per server across replicas. TryAcquire is
+	// non-blocking: it fails when another replica currently holds the lock.
+	lock, err := locks.TryAcquire(ctx, &RegistrationLockKey{ServerURL: normalized})
+	if err != nil {
+		// A peer is registering this server right now. It may already have
+		// finished between our fast-path miss and this acquire attempt; re-check
+		// the cache and return its client so a concurrent first-time
+		// registration does not surface a spurious error. If the peer is still
+		// in flight (no entry yet), surface a retryable error rather than
+		// blocking — core/sync offers no blocking acquire.
+		if existing, ferr := findClient(ctx, clients, normalized); ferr == nil && existing != nil {
+			return existing, nil
+		}
+		return nil, errors.Wrapf(errors.GetErrCode(err),
+			"oauth: registration already in progress for %s: %s", normalized, err)
+	}
+	// Always release the lock, including on the error paths below.
+	defer func() { _ = lock.Close() }()
+
+	// Double-check inside the lock: another replica may have registered between
+	// our fast-path miss and acquiring the lock.
+	existing, err = findClient(ctx, clients, normalized)
+	if err != nil {
+		return nil, err
+	}
+	if existing != nil {
+		return existing, nil
+	}
+
+	return performRegistration(ctx, do, clients, discover, merged, normalized)
+}
+
+// reRegisterClient forces a fresh registration: under the per-server lock it
+// deletes any existing client record and then registers anew. Holding the lock
+// across the delete makes delete-then-register atomic, so a concurrent
+// RegisterDynamicClient cannot slip a client in between (it would block on the
+// lock and then observe the freshly registered client). Used when an existing
+// client may have expired or the server returned invalid_client.
+func reRegisterClient(ctx context.Context, do httpDoFunc, clients clientStore, locks registrationLocker, discover discoverFunc, cfg OAuthConfig, opts RegisterClientOptions) (*ClientEntry, error) {
+	normalized := normalizeServerURL(opts.ServerURL)
+	if normalized == "" {
+		return nil, errors.Wrap(errors.InvalidArgument, "oauth: serverURL must not be empty")
+	}
+	merged := mergeRegisterOptions(cfg, opts)
+
+	// Acquire the lock BEFORE the delete so the replace is atomic. Unlike the
+	// dynamic path there is no fast-path/return-existing on contention: a
+	// re-register caller wants a definitively fresh client, so on lock
+	// contention we surface a retryable error rather than another replica's
+	// (possibly the very client we were asked to replace) entry.
+	lock, err := locks.TryAcquire(ctx, &RegistrationLockKey{ServerURL: normalized})
+	if err != nil {
+		return nil, errors.Wrapf(errors.GetErrCode(err),
+			"oauth: registration already in progress for %s: %s", normalized, err)
+	}
+	defer func() { _ = lock.Close() }()
+
+	// Delete the existing record under the lock; tolerate its absence.
+	if err := clients.DeleteKey(ctx, &ClientKey{ServerURL: normalized}); err != nil && !errors.IsNotFound(err) {
+		return nil, errors.Wrapf(errors.GetErrCode(err),
+			"oauth: failed to delete existing client for %s: %s", normalized, err)
+	}
+
+	return performRegistration(ctx, do, clients, discover, merged, normalized)
+}
+
+// performRegistration runs the RFC 7591 dynamic registration body for an
+// already-normalized server URL: ensure metadata / a registration endpoint,
+// POST the public-client request, and persist the result. The caller MUST hold
+// the per-server registration lock and MUST have established that no client
+// should be returned from cache first (fast-path / double-check, or a delete for
+// re-registration).
+func performRegistration(ctx context.Context, do httpDoFunc, clients clientStore, discover discoverFunc, merged RegisterClientOptions, normalized string) (*ClientEntry, error) {
+	// Ensure we have server metadata, specifically the registration endpoint.
+	server, err := discover(ctx, normalized)
+	if err != nil {
+		return nil, err
+	}
+	if server.RegistrationEndpoint == "" {
+		return nil, errors.Wrapf(errors.InvalidArgument,
+			"oauth: server %s does not advertise a registration endpoint", normalized)
+	}
+
+	// RFC 7591 dynamic registration for a public client.
+	reqBody := clientRegistrationRequest{
+		ClientName:              merged.ClientName,
+		RedirectURIs:            merged.RedirectURIs,
+		GrantTypes:              DefaultGrantTypes(),
+		ResponseTypes:           []string{responseTypeCode},
+		TokenEndpointAuthMethod: TokenEndpointAuthMethodNone,
+		Scope:                   strings.Join(merged.Scopes, " "),
+	}
+	var resp clientRegistrationResponse
+	if err := postJSON(ctx, do, server.RegistrationEndpoint, &reqBody, &resp); err != nil {
+		return nil, errors.Wrapf(errors.GetErrCode(err),
+			"oauth: dynamic client registration failed for %s: %s", normalized, err)
+	}
+	if resp.ClientID == "" {
+		return nil, errors.Wrapf(errors.InvalidArgument,
+			"oauth: registration response for %s did not include a client_id", normalized)
+	}
+
+	entry := &ClientEntry{
+		ClientID:                resp.ClientID,
+		ClientSecret:            resp.ClientSecret,
+		ClientSecretExpiresAt:   resp.ClientSecretExpiresAt,
+		RegistrationURI:         resp.RegistrationClientURI,
+		RegistrationAccessToken: resp.RegistrationAccessToken,
+		RedirectURIs:            preferStrings(resp.RedirectURIs, merged.RedirectURIs),
+		Scopes:                  preferStrings(strings.Fields(resp.Scope), merged.Scopes),
+		ClientType:              clientTypePublic,
+		RegistrationType:        registrationTypeDynamic,
+		RegisteredAt:            time.Now().Unix(),
+	}
+
+	// Persist; sensitive fields are encrypted at rest by ClientEntry.MarshalBSON.
+	if err := clients.Insert(ctx, &ClientKey{ServerURL: normalized}, entry); err != nil {
+		return nil, errors.Wrapf(errors.GetErrCode(err),
+			"oauth: failed to persist registered client for %s: %s", normalized, err)
+	}
+	return entry, nil
+}
+
+// getClient implements GetClient's read-only lookup, mapping a cache miss to
+// (nil, nil).
+func getClient(ctx context.Context, clients clientStore, serverURL string) (*ClientEntry, error) {
+	normalized := normalizeServerURL(serverURL)
+	if normalized == "" {
+		return nil, errors.Wrap(errors.InvalidArgument, "oauth: serverURL must not be empty")
+	}
+	return findClient(ctx, clients, normalized)
+}
+
+// findClient looks up a client by normalized server URL, mapping NotFound to
+// (nil, nil) and surfacing any other error.
+func findClient(ctx context.Context, clients clientStore, normalized string) (*ClientEntry, error) {
+	entry, err := clients.Find(ctx, &ClientKey{ServerURL: normalized})
+	if err != nil {
+		if errors.IsNotFound(err) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	return entry, nil
+}
+
+// mergeRegisterOptions fills unset RegisterClientOptions fields from the manager
+// configuration: ClientName, RedirectURIs (from the single RedirectURI), and
+// Scopes.
+func mergeRegisterOptions(cfg OAuthConfig, opts RegisterClientOptions) RegisterClientOptions {
+	merged := opts
+	if merged.ClientName == "" {
+		merged.ClientName = cfg.ClientName
+	}
+	if len(merged.RedirectURIs) == 0 && cfg.RedirectURI != "" {
+		merged.RedirectURIs = []string{cfg.RedirectURI}
+	}
+	if len(merged.Scopes) == 0 {
+		merged.Scopes = cfg.Scopes
+	}
+	return merged
+}
+
+// preferStrings returns primary when it is non-empty, otherwise fallback. Used
+// to prefer the server-echoed redirect_uris / scope over the requested values.
+func preferStrings(primary, fallback []string) []string {
+	if len(primary) > 0 {
+		return primary
+	}
+	return fallback
+}
+
+// postJSON marshals payload, POSTs it as application/json, and decodes a JSON
+// response body into out, wrapping network, HTTP-status, and parse failures with
+// core/errors codes. The response body is bounded by maxMetadataBytes (defined
+// in discovery.go) so a hostile server cannot exhaust memory.
+func postJSON(ctx context.Context, do httpDoFunc, url string, payload, out any) error {
+	body, err := json.Marshal(payload)
+	if err != nil {
+		return errors.Wrapf(errors.InvalidArgument, "oauth: failed to encode request for %s: %s", url, err)
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(body))
+	if err != nil {
+		return errors.Wrapf(errors.InvalidArgument, "oauth: failed to build request for %s: %s", url, err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", "application/json")
+
+	resp, err := do(req)
+	if err != nil {
+		return errors.Wrapf(errors.Unknown, "oauth: request to %s failed: %s", url, err)
+	}
+	// Share one maxMetadataBytes budget across the parse read and the deferred
+	// drain so the body can never read more than that in total, while still
+	// draining (bounded) on every path so the connection can be reused.
+	limited := io.LimitReader(resp.Body, maxMetadataBytes)
+	defer func() {
+		_, _ = io.Copy(io.Discard, limited)
+		_ = resp.Body.Close()
+	}()
+
+	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
+		return errors.Wrapf(errors.Unknown, "oauth: %s returned HTTP status %d", url, resp.StatusCode)
+	}
+
+	raw, err := io.ReadAll(limited)
+	if err != nil {
+		return errors.Wrapf(errors.Unknown, "oauth: failed to read response from %s: %s", url, err)
+	}
+	if err := json.Unmarshal(raw, out); err != nil {
+		return errors.Wrapf(errors.InvalidArgument, "oauth: failed to parse JSON from %s: %s", url, err)
+	}
+	return nil
+}

--- a/oauth/registration_test.go
+++ b/oauth/registration_test.go
@@ -1,0 +1,565 @@
+// Copyright © 2025-2026 Prabhjot Singh Sethi, All Rights reserved
+// Author: Prabhjot Singh Sethi <prabhjot.sethi@gmail.com>
+
+package oauth
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/go-core-stack/core/errors"
+	coresync "github.com/go-core-stack/core/sync"
+)
+
+// --- fakes ---
+
+// fakeClientStore is an in-memory clientStore recording access counts so tests
+// can assert idempotency, the double-check, and re-registration behavior. onFind
+// is an optional hook invoked with the (1-based) call number before each Find
+// resolves, letting a test seed an entry "between" two lookups to simulate a
+// lost registration race.
+type fakeClientStore struct {
+	entries   map[string]*ClientEntry
+	findCalls int
+	inserts   int
+	deletes   int
+	onFind    func(call int)
+}
+
+func newFakeClientStore() *fakeClientStore {
+	return &fakeClientStore{entries: map[string]*ClientEntry{}}
+}
+
+func (c *fakeClientStore) Find(_ context.Context, key *ClientKey) (*ClientEntry, error) {
+	c.findCalls++
+	if c.onFind != nil {
+		c.onFind(c.findCalls)
+	}
+	e, ok := c.entries[key.ServerURL]
+	if !ok {
+		return nil, errors.Wrapf(errors.NotFound, "no client for %s", key.ServerURL)
+	}
+	return e, nil
+}
+
+func (c *fakeClientStore) Insert(_ context.Context, key *ClientKey, entry *ClientEntry) error {
+	c.inserts++
+	if _, ok := c.entries[key.ServerURL]; ok {
+		return errors.Wrapf(errors.AlreadyExists, "client already exists for %s", key.ServerURL)
+	}
+	c.entries[key.ServerURL] = entry
+	return nil
+}
+
+func (c *fakeClientStore) DeleteKey(_ context.Context, key *ClientKey) error {
+	c.deletes++
+	if _, ok := c.entries[key.ServerURL]; !ok {
+		return errors.Wrapf(errors.NotFound, "no client for %s", key.ServerURL)
+	}
+	delete(c.entries, key.ServerURL)
+	return nil
+}
+
+// fakeRegistrationLocks is a registrationLocker that records the acquire count
+// and retains the issued lock so a test can assert it was released. failWith,
+// when set, makes TryAcquire fail. It reuses the package-shared fakeLock
+// (declared in reconciler_test.go).
+type fakeRegistrationLocks struct {
+	acquires int
+	lock     *fakeLock
+	failWith error
+}
+
+func (l *fakeRegistrationLocks) TryAcquire(_ context.Context, _ *RegistrationLockKey) (coresync.Lock, error) {
+	l.acquires++
+	if l.failWith != nil {
+		return nil, l.failWith
+	}
+	l.lock = &fakeLock{}
+	return l.lock, nil
+}
+
+// released reports whether the most recently issued lock was closed.
+func (l *fakeRegistrationLocks) released() bool {
+	return l.lock != nil && l.lock.closed
+}
+
+// lockObservingStore wraps a clientStore and reports, at DeleteKey time, whether
+// the registration lock was held — so a test can assert delete/register
+// atomicity. "held" means the lock has been acquired and not yet released.
+type lockObservingStore struct {
+	store    *fakeClientStore
+	locks    *fakeRegistrationLocks
+	onDelete func(lockHeld bool)
+}
+
+func (s *lockObservingStore) Find(ctx context.Context, key *ClientKey) (*ClientEntry, error) {
+	return s.store.Find(ctx, key)
+}
+
+func (s *lockObservingStore) Insert(ctx context.Context, key *ClientKey, entry *ClientEntry) error {
+	return s.store.Insert(ctx, key, entry)
+}
+
+func (s *lockObservingStore) DeleteKey(ctx context.Context, key *ClientKey) error {
+	if s.onDelete != nil {
+		s.onDelete(s.locks.acquires > 0 && !s.locks.released())
+	}
+	return s.store.DeleteKey(ctx, key)
+}
+
+// staticDiscover returns a discoverFunc that always yields the given entry.
+func staticDiscover(entry *ServerEntry) discoverFunc {
+	return func(_ context.Context, _ string) (*ServerEntry, error) {
+		return entry, nil
+	}
+}
+
+const regResp = `{
+	"client_id": "client-abc",
+	"client_secret": "secret-xyz",
+	"client_secret_expires_at": 0,
+	"registration_client_uri": "https://as.example.com/register/client-abc",
+	"registration_access_token": "rat-123",
+	"redirect_uris": ["https://app.example.com/callback"],
+	"grant_types": ["authorization_code", "refresh_token"],
+	"scope": "read write"
+}`
+
+func testConfig() OAuthConfig {
+	return OAuthConfig{
+		ClientName:  "test-app",
+		RedirectURI: "https://app.example.com/callback",
+		Scopes:      []string{"read", "write"},
+	}
+}
+
+func discoveredServer() *ServerEntry {
+	return &ServerEntry{
+		TokenEndpoint:        "https://as.example.com/token",
+		RegistrationEndpoint: "https://as.example.com/register",
+	}
+}
+
+// --- tests ---
+
+func TestRegisterDynamicClient_HappyPath(t *testing.T) {
+	locks := &fakeRegistrationLocks{}
+	clients := newFakeClientStore()
+	do := func(_ *http.Request) (*http.Response, error) {
+		return jsonResponse(regResp), nil
+	}
+
+	entry, err := registerDynamicClient(context.Background(), do, clients, locks,
+		staticDiscover(discoveredServer()), testConfig(),
+		RegisterClientOptions{ServerURL: "https://api.example.com"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if entry.ClientID != "client-abc" {
+		t.Errorf("client id = %q", entry.ClientID)
+	}
+	if entry.ClientSecret != "secret-xyz" {
+		t.Errorf("client secret = %q", entry.ClientSecret)
+	}
+	if entry.RegistrationAccessToken != "rat-123" {
+		t.Errorf("registration access token = %q", entry.RegistrationAccessToken)
+	}
+	if entry.ClientType != clientTypePublic {
+		t.Errorf("client type = %q, want %q", entry.ClientType, clientTypePublic)
+	}
+	if entry.RegistrationType != registrationTypeDynamic {
+		t.Errorf("registration type = %q, want %q", entry.RegistrationType, registrationTypeDynamic)
+	}
+	if entry.RegisteredAt == 0 {
+		t.Error("RegisteredAt should be set")
+	}
+	if clients.inserts != 1 {
+		t.Errorf("expected 1 insert, got %d", clients.inserts)
+	}
+	// lock acquired exactly once and released
+	if locks.acquires != 1 || !locks.released() {
+		t.Errorf("lock acquires=%d released=%v, want 1/true", locks.acquires, locks.released())
+	}
+	// persisted under the normalized server key
+	if clients.entries["https://api.example.com"] == nil {
+		t.Errorf("client not persisted under normalized key; keys=%v", clients.entries)
+	}
+}
+
+// The RFC 7591 request must use the public-client configuration.
+func TestRegisterDynamicClient_PublicClientPayload(t *testing.T) {
+	locks := &fakeRegistrationLocks{}
+	clients := newFakeClientStore()
+
+	var sent clientRegistrationRequest
+	var sawPostPath string
+	do := func(req *http.Request) (*http.Response, error) {
+		sawPostPath = req.URL.Path
+		body, _ := io.ReadAll(req.Body)
+		if err := json.Unmarshal(body, &sent); err != nil {
+			t.Fatalf("request body not JSON: %v", err)
+		}
+		if ct := req.Header.Get("Content-Type"); ct != "application/json" {
+			t.Errorf("Content-Type = %q", ct)
+		}
+		return jsonResponse(regResp), nil
+	}
+
+	_, err := registerDynamicClient(context.Background(), do, clients, locks,
+		staticDiscover(discoveredServer()), testConfig(),
+		RegisterClientOptions{ServerURL: "https://api.example.com"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if sawPostPath != "/register" {
+		t.Errorf("registration POST path = %q, want /register", sawPostPath)
+	}
+	if sent.TokenEndpointAuthMethod != TokenEndpointAuthMethodNone {
+		t.Errorf("token_endpoint_auth_method = %q, want %q", sent.TokenEndpointAuthMethod, TokenEndpointAuthMethodNone)
+	}
+	if len(sent.ResponseTypes) != 1 || sent.ResponseTypes[0] != responseTypeCode {
+		t.Errorf("response_types = %v, want [code]", sent.ResponseTypes)
+	}
+	if strings.Join(sent.GrantTypes, ",") != "authorization_code,refresh_token" {
+		t.Errorf("grant_types = %v", sent.GrantTypes)
+	}
+	if sent.ClientName != "test-app" {
+		t.Errorf("client_name = %q (defaults from config)", sent.ClientName)
+	}
+	if len(sent.RedirectURIs) != 1 || sent.RedirectURIs[0] != "https://app.example.com/callback" {
+		t.Errorf("redirect_uris = %v (defaults from config.RedirectURI)", sent.RedirectURIs)
+	}
+	if sent.Scope != "read write" {
+		t.Errorf("scope = %q", sent.Scope)
+	}
+}
+
+// On a cache hit the call is idempotent: it returns the existing client without
+// taking the lock or making a network call.
+func TestRegisterDynamicClient_IdempotentHit(t *testing.T) {
+	locks := &fakeRegistrationLocks{}
+	clients := newFakeClientStore()
+	clients.entries["https://api.example.com"] = &ClientEntry{ClientID: "existing"}
+
+	do := func(req *http.Request) (*http.Response, error) {
+		t.Fatalf("network call made on idempotent hit: %s", req.URL)
+		return nil, nil
+	}
+
+	// trailing slash also exercises key normalization on the hit path
+	entry, err := registerDynamicClient(context.Background(), do, clients, locks,
+		staticDiscover(discoveredServer()), testConfig(),
+		RegisterClientOptions{ServerURL: "https://api.example.com/"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if entry.ClientID != "existing" {
+		t.Errorf("expected existing client, got %q", entry.ClientID)
+	}
+	if locks.acquires != 0 {
+		t.Errorf("idempotent hit must not acquire the lock; acquires=%d", locks.acquires)
+	}
+	if clients.inserts != 0 {
+		t.Errorf("idempotent hit must not insert; inserts=%d", clients.inserts)
+	}
+}
+
+// Two replicas both miss the initial cache check and serialize on the lock; the
+// one that loses the race must observe the winner's entry on the in-lock
+// double-check and return it without registering again.
+func TestRegisterDynamicClient_DoubleCheckUnderLock(t *testing.T) {
+	locks := &fakeRegistrationLocks{}
+	clients := newFakeClientStore()
+	// First Find (fast path) misses; before the second Find (inside the lock)
+	// resolves, seed the entry as if a peer registered while we waited.
+	clients.onFind = func(call int) {
+		if call == 2 {
+			clients.entries["https://api.example.com"] = &ClientEntry{ClientID: "winner"}
+		}
+	}
+
+	do := func(req *http.Request) (*http.Response, error) {
+		t.Fatalf("network call made though double-check should have short-circuited: %s", req.URL)
+		return nil, nil
+	}
+
+	entry, err := registerDynamicClient(context.Background(), do, clients, locks,
+		staticDiscover(discoveredServer()), testConfig(),
+		RegisterClientOptions{ServerURL: "https://api.example.com"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if entry.ClientID != "winner" {
+		t.Errorf("expected peer-registered client, got %q", entry.ClientID)
+	}
+	if locks.acquires != 1 {
+		t.Errorf("expected lock acquired once, got %d", locks.acquires)
+	}
+	if !locks.released() {
+		t.Error("lock must be released even on the double-check short-circuit")
+	}
+	if clients.inserts != 0 {
+		t.Errorf("double-check hit must not insert; inserts=%d", clients.inserts)
+	}
+}
+
+// When the per-server lock is held by a peer that has already finished, the
+// contended caller must observe the peer's client and return it rather than
+// erroring — preserving idempotency under concurrent first-time registration.
+func TestRegisterDynamicClient_LockHeldButPeerFinished(t *testing.T) {
+	locks := &fakeRegistrationLocks{failWith: errors.Wrap(errors.AlreadyExists, "lock held")}
+	clients := newFakeClientStore()
+	// The peer's client appears after our fast-path miss: seed it on the second
+	// Find (the post-acquire-failure re-check).
+	clients.onFind = func(call int) {
+		if call == 2 {
+			clients.entries["https://api.example.com"] = &ClientEntry{ClientID: "peer"}
+		}
+	}
+	do := func(req *http.Request) (*http.Response, error) {
+		t.Fatalf("network call made though a peer already registered: %s", req.URL)
+		return nil, nil
+	}
+
+	entry, err := registerDynamicClient(context.Background(), do, clients, locks,
+		staticDiscover(discoveredServer()), testConfig(),
+		RegisterClientOptions{ServerURL: "https://api.example.com"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if entry.ClientID != "peer" {
+		t.Errorf("expected peer-registered client, got %q", entry.ClientID)
+	}
+	if clients.inserts != 0 {
+		t.Errorf("must not insert when peer already registered; inserts=%d", clients.inserts)
+	}
+}
+
+// When the lock is held and the peer has not finished yet (no entry on
+// re-check), the contended caller must return a retryable error, not register a
+// duplicate.
+func TestRegisterDynamicClient_LockHeldPeerInFlight(t *testing.T) {
+	locks := &fakeRegistrationLocks{failWith: errors.Wrap(errors.AlreadyExists, "lock held")}
+	clients := newFakeClientStore()
+	do := func(req *http.Request) (*http.Response, error) {
+		t.Fatalf("network call made while a peer holds the registration lock: %s", req.URL)
+		return nil, nil
+	}
+
+	_, err := registerDynamicClient(context.Background(), do, clients, locks,
+		staticDiscover(discoveredServer()), testConfig(),
+		RegisterClientOptions{ServerURL: "https://api.example.com"})
+	if err == nil {
+		t.Fatal("expected an error when the registration lock is held and no client exists yet")
+	}
+	if errors.GetErrCode(err) != errors.AlreadyExists {
+		t.Errorf("expected a retryable (AlreadyExists) error on lock contention, got %v", err)
+	}
+	if clients.inserts != 0 {
+		t.Errorf("must not insert while contended; inserts=%d", clients.inserts)
+	}
+}
+
+func TestRegisterDynamicClient_NoRegistrationEndpoint(t *testing.T) {
+	locks := &fakeRegistrationLocks{}
+	clients := newFakeClientStore()
+	do := func(req *http.Request) (*http.Response, error) {
+		t.Fatalf("should not POST when no registration endpoint: %s", req.URL)
+		return nil, nil
+	}
+
+	_, err := registerDynamicClient(context.Background(), do, clients, locks,
+		staticDiscover(&ServerEntry{TokenEndpoint: "https://as.example.com/token"}), testConfig(),
+		RegisterClientOptions{ServerURL: "https://api.example.com"})
+	if err == nil {
+		t.Fatal("expected error when server advertises no registration endpoint")
+	}
+	if !errors.IsInvalidArgument(err) {
+		t.Errorf("expected InvalidArgument, got %v", err)
+	}
+	// lock acquired then released even on this error path
+	if locks.acquires != 1 || !locks.released() {
+		t.Errorf("lock acquires=%d released=%v, want 1/true", locks.acquires, locks.released())
+	}
+}
+
+func TestReRegisterClient_DeletesThenRegisters(t *testing.T) {
+	locks := &fakeRegistrationLocks{}
+	clients := newFakeClientStore()
+	clients.entries["https://api.example.com"] = &ClientEntry{ClientID: "stale"}
+
+	do := func(_ *http.Request) (*http.Response, error) {
+		return jsonResponse(regResp), nil
+	}
+
+	entry, err := reRegisterClient(context.Background(), do, clients, locks,
+		staticDiscover(discoveredServer()), testConfig(),
+		RegisterClientOptions{ServerURL: "https://api.example.com"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if clients.deletes != 1 {
+		t.Errorf("expected 1 delete, got %d", clients.deletes)
+	}
+	if entry.ClientID != "client-abc" {
+		t.Errorf("expected freshly-registered client, got %q", entry.ClientID)
+	}
+	if got := clients.entries["https://api.example.com"]; got == nil || got.ClientID != "client-abc" {
+		t.Errorf("re-registered client not persisted; got %v", got)
+	}
+}
+
+// Re-registration must succeed even when there is no existing client to delete.
+func TestReRegisterClient_NoExistingClient(t *testing.T) {
+	locks := &fakeRegistrationLocks{}
+	clients := newFakeClientStore()
+	do := func(_ *http.Request) (*http.Response, error) {
+		return jsonResponse(regResp), nil
+	}
+
+	entry, err := reRegisterClient(context.Background(), do, clients, locks,
+		staticDiscover(discoveredServer()), testConfig(),
+		RegisterClientOptions{ServerURL: "https://api.example.com"})
+	if err != nil {
+		t.Fatalf("unexpected error (delete of absent client must be tolerated): %v", err)
+	}
+	if entry.ClientID != "client-abc" {
+		t.Errorf("expected registered client, got %q", entry.ClientID)
+	}
+}
+
+// Re-registration must acquire the lock BEFORE deleting, so the delete and the
+// fresh registration are atomic.
+func TestReRegisterClient_LocksBeforeDeleting(t *testing.T) {
+	clients := newFakeClientStore()
+	clients.entries["https://api.example.com"] = &ClientEntry{ClientID: "stale"}
+	// onFind asserts the lock is held before any client mutation; re-register
+	// must not consult the cache fast-path, but if the implementation ever did,
+	// the lock must already be held.
+	locks := &fakeRegistrationLocks{}
+
+	deletedWithLock := false
+	clientsHook := &lockObservingStore{store: clients, locks: locks, onDelete: func(held bool) {
+		deletedWithLock = held
+	}}
+
+	do := func(_ *http.Request) (*http.Response, error) {
+		return jsonResponse(regResp), nil
+	}
+
+	_, err := reRegisterClient(context.Background(), do, clientsHook, locks,
+		staticDiscover(discoveredServer()), testConfig(),
+		RegisterClientOptions{ServerURL: "https://api.example.com"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if locks.acquires != 1 {
+		t.Errorf("expected lock acquired once, got %d", locks.acquires)
+	}
+	if !deletedWithLock {
+		t.Error("delete must happen while the registration lock is held")
+	}
+	if !locks.released() {
+		t.Error("lock must be released")
+	}
+}
+
+// On lock contention, re-register must fail (retryable) rather than return a
+// peer's client or register a duplicate — the delete must not be skipped
+// silently.
+func TestReRegisterClient_LockContentionFailsRetryable(t *testing.T) {
+	locks := &fakeRegistrationLocks{failWith: errors.Wrap(errors.AlreadyExists, "lock held")}
+	clients := newFakeClientStore()
+	clients.entries["https://api.example.com"] = &ClientEntry{ClientID: "stale"}
+	do := func(req *http.Request) (*http.Response, error) {
+		t.Fatalf("network call made while the lock is held: %s", req.URL)
+		return nil, nil
+	}
+
+	_, err := reRegisterClient(context.Background(), do, clients, locks,
+		staticDiscover(discoveredServer()), testConfig(),
+		RegisterClientOptions{ServerURL: "https://api.example.com"})
+	if err == nil {
+		t.Fatal("expected a retryable error on lock contention")
+	}
+	if errors.GetErrCode(err) != errors.AlreadyExists {
+		t.Errorf("expected a retryable (AlreadyExists) error on lock contention, got %v", err)
+	}
+	if clients.deletes != 0 {
+		t.Errorf("must not delete when the lock could not be acquired; deletes=%d", clients.deletes)
+	}
+	if clients.inserts != 0 {
+		t.Errorf("must not register when the lock could not be acquired; inserts=%d", clients.inserts)
+	}
+}
+
+func TestGetClient_HitAndMiss(t *testing.T) {
+	clients := newFakeClientStore()
+
+	got, err := getClient(context.Background(), clients, "https://api.example.com/")
+	if err != nil {
+		t.Fatalf("unexpected error on miss: %v", err)
+	}
+	if got != nil {
+		t.Errorf("expected nil on miss, got %v", got)
+	}
+
+	clients.entries["https://api.example.com"] = &ClientEntry{ClientID: "client-abc"}
+	got, err = getClient(context.Background(), clients, "https://api.example.com")
+	if err != nil {
+		t.Fatalf("unexpected error on hit: %v", err)
+	}
+	if got == nil || got.ClientID != "client-abc" {
+		t.Errorf("expected stored client, got %v", got)
+	}
+}
+
+func TestRegisterStaticClient_Unimplemented(t *testing.T) {
+	m := &OAuthManager{}
+	err := m.RegisterStaticClient(context.Background(), "https://api.example.com", ClientEntry{})
+	if err == nil {
+		t.Fatal("expected an error from the static-registration stub")
+	}
+	if !errors.Is(err, errStaticRegistrationUnimplemented) {
+		t.Errorf("expected errStaticRegistrationUnimplemented, got %v", err)
+	}
+}
+
+func TestMergeRegisterOptions_DefaultsAndOverrides(t *testing.T) {
+	cfg := testConfig()
+
+	// empty opts -> all defaults from config
+	got := mergeRegisterOptions(cfg, RegisterClientOptions{ServerURL: "https://api.example.com"})
+	if got.ClientName != "test-app" {
+		t.Errorf("ClientName = %q", got.ClientName)
+	}
+	if len(got.RedirectURIs) != 1 || got.RedirectURIs[0] != "https://app.example.com/callback" {
+		t.Errorf("RedirectURIs = %v", got.RedirectURIs)
+	}
+	if strings.Join(got.Scopes, ",") != "read,write" {
+		t.Errorf("Scopes = %v", got.Scopes)
+	}
+
+	// explicit opts win over config
+	got = mergeRegisterOptions(cfg, RegisterClientOptions{
+		ServerURL:    "https://api.example.com",
+		ClientName:   "custom",
+		RedirectURIs: []string{"https://other/cb"},
+		Scopes:       []string{"openid"},
+	})
+	if got.ClientName != "custom" {
+		t.Errorf("override ClientName = %q", got.ClientName)
+	}
+	if len(got.RedirectURIs) != 1 || got.RedirectURIs[0] != "https://other/cb" {
+		t.Errorf("override RedirectURIs = %v", got.RedirectURIs)
+	}
+	if strings.Join(got.Scopes, ",") != "openid" {
+		t.Errorf("override Scopes = %v", got.Scopes)
+	}
+}


### PR DESCRIPTION
## Summary

Implements RFC 7591 dynamic client registration for the OAuth client library (`oauth/registration.go`), mapping to Commit 4 of the source plan and task **AUTH-0005**.

Adds four methods on `OAuthManager`:

- `RegisterDynamicClient` — RFC 7591 dynamic registration for **public** clients (`token_endpoint_auth_method: "none"`, `response_types: ["code"]`, `grant_types: ["authorization_code", "refresh_token"]`). Idempotent: returns the existing client on a cache hit. Serialized per server via a distributed lock with an in-lock double-check; on lock contention it re-checks the cache and returns a peer's client if registration already completed, otherwise a retryable error.
- `ReRegisterClient` — forces a fresh registration. Acquires the per-server lock **before** deleting the existing record, so delete-then-register is atomic.
- `GetClient` — read-only lookup; returns `(nil, nil)` on miss, no network call.
- `RegisterStaticClient` — interface-only stub (deferred per OPEN-POINTS #2); returns a sentinel "unimplemented" error matchable via `errors.Is`.

Sensitive client fields (`ClientSecret`, `RegistrationAccessToken`) are encrypted at rest via the existing `ClientEntry.MarshalBSON`. Server URLs are normalized consistently for cache keys, lock keys, and well-known URL building.

## Notes for reviewers

- `core/errors` has no `Unimplemented` code, so `RegisterStaticClient` returns a package sentinel (`errStaticRegistrationUnimplemented`), mirroring the existing `errRefreshNotImplemented` pattern in `reconciler.go`. Returning a literal `errors.Unimplemented` would require an upstream `core` change — out of scope for this task. Static registration is deferred regardless (OPEN-POINTS #2).
- The registration lock is intentionally held across the discovery + registration POST to serialize registration across replicas (a rare, first-registration-only path).

## Testing

- `go build ./...`, `go vet ./oauth/...`, full `go test ./...`, `go test -race ./oauth/...`, and `golangci-lint run ./oauth/...` (0 issues) all pass.
- New tests cover: happy path, public-client payload, idempotent hit, in-lock double-check, lock-contention (peer-finished and peer-in-flight), re-registration (delete-then-register, no existing client, locks-before-delete, contention), `GetClient` hit/miss, static stub, and option merging.

Refs: AUTH-0005

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added OAuth 2.0 dynamic client registration with idempotent registration and automatic concurrency control across distributed replicas to prevent duplicate client registrations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->