### PR TITLE
feat(oauth): implement Authorization Code + PKCE flow (AUTH-0006)

### DIFF
--- a/oauth/authorization.go
+++ b/oauth/authorization.go
@@ -1,0 +1,353 @@
+// Copyright © 2025-2026 Prabhjot Singh Sethi, All Rights reserved
+// Author: Prabhjot Singh Sethi <prabhjot.sethi@gmail.com>
+
+package oauth
+
+import (
+	"context"
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/json"
+	"io"
+	"log"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+
+	"github.com/go-core-stack/core/errors"
+)
+
+// Authorization Code + PKCE protocol constants.
+const (
+	grantTypeAuthorizationCode = "authorization_code"
+
+	// codeVerifierBytes is the number of random bytes drawn for a PKCE code
+	// verifier. 32 bytes base64url-encode (no padding) to a 43-character
+	// verifier, the minimum length RFC 7636 §4.1 permits.
+	codeVerifierBytes = 32
+	// stateBytes is the number of random bytes drawn for the CSRF state token.
+	stateBytes = 32
+)
+
+// pendingStore is the subset of the pending-auth-state table the authorization
+// flow needs. The concrete *table.Table[PendingAuthStateKey, PendingAuthState]
+// satisfies it; tests substitute a fake so the PKCE/exchange paths are exercised
+// without a live MongoDB.
+type pendingStore interface {
+	Insert(ctx context.Context, key *PendingAuthStateKey, entry *PendingAuthState) error
+	Find(ctx context.Context, key *PendingAuthStateKey) (*PendingAuthState, error)
+	DeleteKey(ctx context.Context, key *PendingAuthStateKey) error
+}
+
+// tokenWriter is the subset of the token table the callback handler needs. It
+// upserts (Locate) rather than inserts so a re-authorization overwrites any
+// existing token for the (server, account) pair.
+type tokenWriter interface {
+	Locate(ctx context.Context, key *TokenKey, entry *TokenEntry) error
+}
+
+// tokenResponse is the RFC 6749 §5.1 access-token response. Parsed defensively:
+// optional fields are simply absent when omitted by the server.
+type tokenResponse struct {
+	AccessToken  string `json:"access_token"`
+	TokenType    string `json:"token_type"`
+	ExpiresIn    int64  `json:"expires_in"`
+	RefreshToken string `json:"refresh_token"`
+	Scope        string `json:"scope"`
+	IDToken      string `json:"id_token"`
+}
+
+// AuthorizationURL builds the Authorization Code + PKCE request parameters for a
+// remote server and persists the transient state needed to complete the flow. It
+// generates a PKCE verifier/challenge (S256) and a CSRF state token, stores a
+// PendingAuthState (verifier encrypted at rest) keyed by the state, and returns
+// the tokenized *AuthorizationParams — the consumer assembles the final redirect
+// URL. The state value in the eventual callback URL is the only session handle;
+// no in-memory session is kept.
+func (m *OAuthManager) AuthorizationURL(ctx context.Context, opts AuthorizeOptions) (*AuthorizationParams, error) {
+	return authorizationURL(ctx, m.serverTable, m.clientTable, m.pendingTable, m.config, opts)
+}
+
+// HandleCallback completes the Authorization Code + PKCE flow: it looks up the
+// pending state by the returned CSRF state, exchanges the authorization code for
+// tokens at the server's token endpoint (presenting the stored PKCE verifier),
+// persists the resulting token (encrypted, state=active) keyed by
+// {serverURL, accountId}, and deletes the now-consumed pending state. An unknown
+// or expired state yields a clear error.
+//
+// Security note: the account the token is stored under is taken from the
+// server-side PendingAuthState bound at AuthorizationURL time — never from the
+// callback request — so a callback cannot be steered to a different account. The
+// state value is the CSRF/session handle, but the library cannot verify that the
+// browser completing the callback is the same one that began the flow. The
+// consuming service MUST bind the state (or the resulting account) to its own
+// authenticated session before calling this, and reject a mismatch, to prevent
+// login-CSRF / session-fixation.
+func (m *OAuthManager) HandleCallback(ctx context.Context, state string, code string) (*TokenEntry, error) {
+	return handleCallback(ctx, m.httpDo, m.serverTable, m.pendingTable, m.tokenTable, state, code)
+}
+
+// authorizationURL implements AuthorizationURL against the
+// serverCache/clientStore/pendingStore interfaces so it is unit-testable with
+// fakes.
+func authorizationURL(ctx context.Context, servers serverCache, clients clientStore, pending pendingStore, cfg OAuthConfig, opts AuthorizeOptions) (*AuthorizationParams, error) {
+	normalized := normalizeServerURL(opts.ServerURL)
+	if normalized == "" {
+		return nil, errors.Wrap(errors.InvalidArgument, "oauth: serverURL must not be empty")
+	}
+	if strings.TrimSpace(opts.AccountID) == "" {
+		return nil, errors.Wrap(errors.InvalidArgument, "oauth: accountID must not be empty")
+	}
+	merged := mergeAuthorizeOptions(cfg, opts)
+	if merged.RedirectURI == "" {
+		return nil, errors.Wrap(errors.InvalidArgument,
+			"oauth: redirectURI must be set via AuthorizeOptions or OAuthConfig")
+	}
+
+	// The client must already be registered and the server already discovered:
+	// the consumer drives registration/discovery before starting a flow.
+	client, err := findClient(ctx, clients, normalized)
+	if err != nil {
+		return nil, err
+	}
+	if client == nil {
+		return nil, errors.Wrapf(errors.NotFound,
+			"oauth: no registered client for %s; register before authorizing", normalized)
+	}
+
+	server, err := getCachedServer(ctx, servers, normalized)
+	if err != nil {
+		return nil, err
+	}
+	if server == nil {
+		return nil, errors.Wrapf(errors.NotFound,
+			"oauth: server %s not discovered; discover before authorizing", normalized)
+	}
+	if server.AuthorizationEndpoint == "" {
+		return nil, errors.Wrapf(errors.InvalidArgument,
+			"oauth: server %s does not advertise an authorization endpoint", normalized)
+	}
+
+	// PKCE (S256) and CSRF state, both from crypto/rand.
+	verifier, err := generateRandomToken(codeVerifierBytes)
+	if err != nil {
+		return nil, errors.Wrapf(errors.GetErrCode(err), "oauth: failed to generate PKCE verifier: %s", err)
+	}
+	state, err := generateRandomToken(stateBytes)
+	if err != nil {
+		return nil, errors.Wrapf(errors.GetErrCode(err), "oauth: failed to generate CSRF state: %s", err)
+	}
+
+	// Persist the transient state; the verifier is encrypted at rest by
+	// PendingAuthState.MarshalBSON. Everything needed to finish the exchange
+	// lives here, so the callback needs no in-memory session.
+	ps := &PendingAuthState{
+		ServerURL:    normalized,
+		AccountID:    merged.AccountID,
+		ClientID:     client.ClientID,
+		CodeVerifier: verifier,
+		RedirectURI:  merged.RedirectURI,
+		Scopes:       merged.Scopes,
+		CreatedAt:    time.Now(),
+	}
+	if err := pending.Insert(ctx, &PendingAuthStateKey{State: state}, ps); err != nil {
+		return nil, errors.Wrapf(errors.GetErrCode(err),
+			"oauth: failed to persist pending authorization state for %s: %s", normalized, err)
+	}
+
+	return &AuthorizationParams{
+		Endpoint:            server.AuthorizationEndpoint,
+		ClientID:            client.ClientID,
+		RedirectURI:         merged.RedirectURI,
+		ResponseType:        responseTypeCode,
+		Scope:               strings.Join(merged.Scopes, " "),
+		State:               state,
+		CodeChallenge:       codeChallengeS256(verifier),
+		CodeChallengeMethod: CodeChallengeMethodS256,
+		ExtraParams:         merged.ExtraParams,
+	}, nil
+}
+
+// handleCallback implements HandleCallback against the
+// pendingStore/serverCache/tokenWriter/httpDoFunc interfaces so it is
+// unit-testable with fakes.
+func handleCallback(ctx context.Context, do httpDoFunc, servers serverCache, pending pendingStore, tokens tokenWriter, state, code string) (*TokenEntry, error) {
+	if strings.TrimSpace(state) == "" {
+		return nil, errors.Wrap(errors.InvalidArgument, "oauth: callback state must not be empty")
+	}
+	if strings.TrimSpace(code) == "" {
+		return nil, errors.Wrap(errors.InvalidArgument, "oauth: callback code must not be empty")
+	}
+
+	stateKey := &PendingAuthStateKey{State: state}
+	ps, err := pending.Find(ctx, stateKey)
+	if err != nil {
+		if errors.IsNotFound(err) {
+			return nil, errors.Wrap(errors.NotFound,
+				"oauth: unknown or expired authorization state")
+		}
+		return nil, err
+	}
+
+	// Defence-in-depth against TTL-sweep lag (and non-MongoDB/fake stores that
+	// don't reap at all): the IdP code single-use, PKCE binding, and CSRF state
+	// entropy already bound the callback window, but enforce the advertised
+	// PendingStateTTL here too rather than trust a lingering state. Best-effort
+	// delete, then return the same opaque error as an unknown state.
+	if !ps.CreatedAt.Add(PendingStateTTL).After(time.Now()) {
+		_ = pending.DeleteKey(ctx, stateKey)
+		return nil, errors.Wrap(errors.NotFound,
+			"oauth: unknown or expired authorization state")
+	}
+
+	server, err := getCachedServer(ctx, servers, ps.ServerURL)
+	if err != nil {
+		return nil, err
+	}
+	if server == nil || server.TokenEndpoint == "" {
+		return nil, errors.Wrapf(errors.InvalidArgument,
+			"oauth: server %s has no usable token endpoint", ps.ServerURL)
+	}
+
+	// RFC 6749 §4.1.3 / RFC 7636 §4.5 authorization-code exchange for a public
+	// client, presenting the stored PKCE verifier. The client_id is the one that
+	// initiated the flow (persisted in the pending state), not whatever is
+	// currently registered: the authorization code is bound to the initiating
+	// client, so a re-registration between AuthorizationURL and HandleCallback
+	// must not change the client_id presented at the exchange.
+	form := url.Values{}
+	form.Set("grant_type", grantTypeAuthorizationCode)
+	form.Set("code", code)
+	form.Set("code_verifier", ps.CodeVerifier)
+	form.Set("client_id", ps.ClientID)
+	form.Set("redirect_uri", ps.RedirectURI)
+
+	var tr tokenResponse
+	if err := postForm(ctx, do, server.TokenEndpoint, form, &tr); err != nil {
+		return nil, errors.Wrapf(errors.GetErrCode(err),
+			"oauth: authorization code exchange failed for %s: %s", ps.ServerURL, err)
+	}
+	if tr.AccessToken == "" {
+		return nil, errors.Wrapf(errors.InvalidArgument,
+			"oauth: token response for %s did not include an access_token", ps.ServerURL)
+	}
+
+	entry := newTokenEntry(&tr, ps, time.Now())
+
+	// Persist the token BEFORE deleting the pending state: if persistence fails
+	// the state survives (TTL-bounded) for a retry, and we never drop the
+	// verifier with no token to show for it. Sensitive fields are encrypted at
+	// rest by TokenEntry.MarshalBSON.
+	tokenKey := &TokenKey{ServerURL: ps.ServerURL, AccountID: ps.AccountID}
+	if err := tokens.Locate(ctx, tokenKey, entry); err != nil {
+		return nil, errors.Wrapf(errors.GetErrCode(err),
+			"oauth: failed to persist token for %s/%s: %s", ps.ServerURL, ps.AccountID, err)
+	}
+
+	// Consume the single-use pending state. The token is already durably stored,
+	// so a delete failure is non-fatal: the TTL index and stale-state reconciler
+	// reap the entry, and its state value cannot be replayed against a missing
+	// record without also reproducing the (single-use) authorization code.
+	if err := pending.DeleteKey(ctx, stateKey); err != nil && !errors.IsNotFound(err) {
+		log.Printf("oauth: failed to delete consumed pending auth state for %s/%s: %s",
+			ps.ServerURL, ps.AccountID, err)
+	}
+
+	return entry, nil
+}
+
+// newTokenEntry builds an active TokenEntry from a token response and the pending
+// state it completes. ExpiresAt is derived from expires_in relative to now;
+// LastRefresh records the issuance instant so the refresh reconciler can apply
+// its lifetime-fraction heuristic. Scopes fall back to the requested scopes when
+// the server does not echo them.
+func newTokenEntry(tr *tokenResponse, ps *PendingAuthState, now time.Time) *TokenEntry {
+	entry := &TokenEntry{
+		AccessToken:  tr.AccessToken,
+		TokenType:    tr.TokenType,
+		RefreshToken: tr.RefreshToken,
+		Scopes:       preferStrings(strings.Fields(tr.Scope), ps.Scopes),
+		IDToken:      tr.IDToken,
+		State:        SessionActive,
+		LastRefresh:  now.Unix(),
+	}
+	if tr.ExpiresIn > 0 {
+		entry.ExpiresAt = now.Add(time.Duration(tr.ExpiresIn) * time.Second).Unix()
+	}
+	return entry
+}
+
+// mergeAuthorizeOptions fills unset AuthorizeOptions fields from the manager
+// configuration: RedirectURI and Scopes. AccountID and ExtraParams pass through
+// verbatim.
+func mergeAuthorizeOptions(cfg OAuthConfig, opts AuthorizeOptions) AuthorizeOptions {
+	merged := opts
+	if merged.RedirectURI == "" {
+		merged.RedirectURI = cfg.RedirectURI
+	}
+	if len(merged.Scopes) == 0 {
+		merged.Scopes = cfg.Scopes
+	}
+	return merged
+}
+
+// generateRandomToken returns n cryptographically random bytes encoded as
+// base64url without padding (RFC 7636 §4.1 / §4.2), suitable for a PKCE verifier
+// or a CSRF state token.
+func generateRandomToken(n int) (string, error) {
+	b := make([]byte, n)
+	if _, err := rand.Read(b); err != nil {
+		return "", errors.Wrapf(errors.Unknown, "oauth: failed to read random bytes: %s", err)
+	}
+	return base64.RawURLEncoding.EncodeToString(b), nil
+}
+
+// codeChallengeS256 derives the PKCE S256 code challenge from a verifier:
+// base64url(SHA256(verifier)) without padding (RFC 7636 §4.2).
+func codeChallengeS256(verifier string) string {
+	sum := sha256.Sum256([]byte(verifier))
+	return base64.RawURLEncoding.EncodeToString(sum[:])
+}
+
+// postForm POSTs form as application/x-www-form-urlencoded and decodes a JSON
+// response body into out, wrapping network, HTTP-status, and parse failures with
+// core/errors codes. The token endpoint takes form-encoded input (RFC 6749
+// §4.1.3) but returns JSON (§5.1). The response body is bounded by
+// maxMetadataBytes (defined in discovery.go) so a hostile server cannot exhaust
+// memory.
+func postForm(ctx context.Context, do httpDoFunc, endpoint string, form url.Values, out any) error {
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint, strings.NewReader(form.Encode()))
+	if err != nil {
+		return errors.Wrapf(errors.InvalidArgument, "oauth: failed to build request for %s: %s", endpoint, err)
+	}
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req.Header.Set("Accept", "application/json")
+
+	resp, err := do(req)
+	if err != nil {
+		return errors.Wrapf(errors.Unknown, "oauth: request to %s failed: %s", endpoint, err)
+	}
+	// Share one maxMetadataBytes budget across the parse read and the deferred
+	// drain so the body can never read more than that in total, while still
+	// draining (bounded) on every path so the connection can be reused.
+	limited := io.LimitReader(resp.Body, maxMetadataBytes)
+	defer func() {
+		_, _ = io.Copy(io.Discard, limited)
+		_ = resp.Body.Close()
+	}()
+
+	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
+		return errors.Wrapf(errors.Unknown, "oauth: %s returned HTTP status %d", endpoint, resp.StatusCode)
+	}
+
+	raw, err := io.ReadAll(limited)
+	if err != nil {
+		return errors.Wrapf(errors.Unknown, "oauth: failed to read response from %s: %s", endpoint, err)
+	}
+	if err := json.Unmarshal(raw, out); err != nil {
+		return errors.Wrapf(errors.InvalidArgument, "oauth: failed to parse JSON from %s: %s", endpoint, err)
+	}
+	return nil
+}

--- a/oauth/authorization_test.go
+++ b/oauth/authorization_test.go
@@ -1,0 +1,533 @@
+// Copyright © 2025-2026 Prabhjot Singh Sethi, All Rights reserved
+// Author: Prabhjot Singh Sethi <prabhjot.sethi@gmail.com>
+
+package oauth
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/base64"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/go-core-stack/core/errors"
+)
+
+// --- fakes ---
+
+// fakePendingStore is an in-memory pendingStore recording access counts so tests
+// can assert persistence and single-use deletion of pending authorization state.
+type fakePendingStore struct {
+	entries map[string]*PendingAuthState
+	inserts int
+	finds   int
+	deletes int
+}
+
+func newFakePendingStore() *fakePendingStore {
+	return &fakePendingStore{entries: map[string]*PendingAuthState{}}
+}
+
+func (p *fakePendingStore) Insert(_ context.Context, key *PendingAuthStateKey, entry *PendingAuthState) error {
+	p.inserts++
+	if _, ok := p.entries[key.State]; ok {
+		return errors.Wrapf(errors.AlreadyExists, "pending state already exists for %s", key.State)
+	}
+	p.entries[key.State] = entry
+	return nil
+}
+
+func (p *fakePendingStore) Find(_ context.Context, key *PendingAuthStateKey) (*PendingAuthState, error) {
+	p.finds++
+	e, ok := p.entries[key.State]
+	if !ok {
+		return nil, errors.Wrapf(errors.NotFound, "no pending state for %s", key.State)
+	}
+	return e, nil
+}
+
+func (p *fakePendingStore) DeleteKey(_ context.Context, key *PendingAuthStateKey) error {
+	p.deletes++
+	if _, ok := p.entries[key.State]; !ok {
+		return errors.Wrapf(errors.NotFound, "no pending state for %s", key.State)
+	}
+	delete(p.entries, key.State)
+	return nil
+}
+
+// fakeTokenWriter is an in-memory tokenWriter capturing the upserted token so a
+// test can assert what was persisted and under which key.
+type fakeTokenWriter struct {
+	entries map[TokenKey]*TokenEntry
+	locates int
+}
+
+func newFakeTokenWriter() *fakeTokenWriter {
+	return &fakeTokenWriter{entries: map[TokenKey]*TokenEntry{}}
+}
+
+func (w *fakeTokenWriter) Locate(_ context.Context, key *TokenKey, entry *TokenEntry) error {
+	w.locates++
+	w.entries[*key] = entry
+	return nil
+}
+
+// authServer returns a discovered server with both authorization and token
+// endpoints populated.
+func authServer() *ServerEntry {
+	return &ServerEntry{
+		AuthorizationEndpoint: "https://as.example.com/authorize",
+		TokenEndpoint:         "https://as.example.com/token",
+	}
+}
+
+const tokenResp = `{
+	"access_token": "at-123",
+	"token_type": "Bearer",
+	"expires_in": 3600,
+	"refresh_token": "rt-456",
+	"scope": "read write",
+	"id_token": "id-789"
+}`
+
+// --- AuthorizationURL tests ---
+
+func TestAuthorizationURL_ParamsCorrectness(t *testing.T) {
+	servers := newFakeServerCache()
+	servers.entries["https://api.example.com"] = authServer()
+	clients := newFakeClientStore()
+	clients.entries["https://api.example.com"] = &ClientEntry{ClientID: "client-abc"}
+	pending := newFakePendingStore()
+
+	params, err := authorizationURL(context.Background(), servers, clients, pending, testConfig(),
+		AuthorizeOptions{
+			ServerURL:   "https://api.example.com/",
+			AccountID:   "acct-1",
+			ExtraParams: map[string]string{"resource": "https://mcp.example.com"},
+		})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if params.Endpoint != "https://as.example.com/authorize" {
+		t.Errorf("Endpoint = %q", params.Endpoint)
+	}
+	if params.ClientID != "client-abc" {
+		t.Errorf("ClientID = %q", params.ClientID)
+	}
+	if params.RedirectURI != "https://app.example.com/callback" {
+		t.Errorf("RedirectURI = %q (should default from config)", params.RedirectURI)
+	}
+	if params.ResponseType != responseTypeCode {
+		t.Errorf("ResponseType = %q, want %q", params.ResponseType, responseTypeCode)
+	}
+	if params.Scope != "read write" {
+		t.Errorf("Scope = %q (should default from config)", params.Scope)
+	}
+	if params.CodeChallengeMethod != CodeChallengeMethodS256 {
+		t.Errorf("CodeChallengeMethod = %q, want %q", params.CodeChallengeMethod, CodeChallengeMethodS256)
+	}
+	if params.State == "" {
+		t.Error("State must be populated")
+	}
+	if params.CodeChallenge == "" {
+		t.Error("CodeChallenge must be populated")
+	}
+	if params.ExtraParams["resource"] != "https://mcp.example.com" {
+		t.Errorf("ExtraParams not passed through: %v", params.ExtraParams)
+	}
+
+	// pending state persisted under the returned state, keyed to the normalized
+	// server URL, with the verifier stored.
+	if pending.inserts != 1 {
+		t.Errorf("expected 1 pending insert, got %d", pending.inserts)
+	}
+	ps := pending.entries[params.State]
+	if ps == nil {
+		t.Fatalf("pending state not persisted under state %q", params.State)
+	}
+	if ps.ServerURL != "https://api.example.com" {
+		t.Errorf("pending ServerURL = %q (should be normalized)", ps.ServerURL)
+	}
+	if ps.AccountID != "acct-1" {
+		t.Errorf("pending AccountID = %q", ps.AccountID)
+	}
+	// The initiating client is persisted so the callback exchanges the code
+	// against the same client_id, even if the client is re-registered meanwhile.
+	if ps.ClientID != "client-abc" {
+		t.Errorf("pending ClientID = %q", ps.ClientID)
+	}
+	if ps.CodeVerifier == "" {
+		t.Error("pending CodeVerifier must be set")
+	}
+	if ps.RedirectURI != "https://app.example.com/callback" {
+		t.Errorf("pending RedirectURI = %q", ps.RedirectURI)
+	}
+
+	// The challenge must be the S256 transform of the stored verifier.
+	sum := sha256.Sum256([]byte(ps.CodeVerifier))
+	want := base64.RawURLEncoding.EncodeToString(sum[:])
+	if params.CodeChallenge != want {
+		t.Errorf("CodeChallenge = %q, want S256(verifier) = %q", params.CodeChallenge, want)
+	}
+}
+
+// Each call must mint a distinct verifier and state (crypto/rand).
+func TestAuthorizationURL_UniquePerCall(t *testing.T) {
+	servers := newFakeServerCache()
+	servers.entries["https://api.example.com"] = authServer()
+	clients := newFakeClientStore()
+	clients.entries["https://api.example.com"] = &ClientEntry{ClientID: "client-abc"}
+	pending := newFakePendingStore()
+
+	opts := AuthorizeOptions{ServerURL: "https://api.example.com", AccountID: "acct-1"}
+	first, err := authorizationURL(context.Background(), servers, clients, pending, testConfig(), opts)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	second, err := authorizationURL(context.Background(), servers, clients, pending, testConfig(), opts)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if first.State == second.State {
+		t.Error("state must differ between calls")
+	}
+	if first.CodeChallenge == second.CodeChallenge {
+		t.Error("code challenge must differ between calls")
+	}
+}
+
+func TestAuthorizationURL_RequiresRegisteredClient(t *testing.T) {
+	servers := newFakeServerCache()
+	servers.entries["https://api.example.com"] = authServer()
+	clients := newFakeClientStore() // empty
+	pending := newFakePendingStore()
+
+	_, err := authorizationURL(context.Background(), servers, clients, pending, testConfig(),
+		AuthorizeOptions{ServerURL: "https://api.example.com", AccountID: "acct-1"})
+	if err == nil {
+		t.Fatal("expected error when no client is registered")
+	}
+	if !errors.IsNotFound(err) {
+		t.Errorf("expected NotFound, got %v", err)
+	}
+	if pending.inserts != 0 {
+		t.Errorf("must not persist pending state without a client; inserts=%d", pending.inserts)
+	}
+}
+
+func TestAuthorizationURL_RequiresDiscoveredServer(t *testing.T) {
+	servers := newFakeServerCache() // empty
+	clients := newFakeClientStore()
+	clients.entries["https://api.example.com"] = &ClientEntry{ClientID: "client-abc"}
+	pending := newFakePendingStore()
+
+	_, err := authorizationURL(context.Background(), servers, clients, pending, testConfig(),
+		AuthorizeOptions{ServerURL: "https://api.example.com", AccountID: "acct-1"})
+	if err == nil {
+		t.Fatal("expected error when server is not discovered")
+	}
+	if !errors.IsNotFound(err) {
+		t.Errorf("expected NotFound, got %v", err)
+	}
+}
+
+func TestAuthorizationURL_RequiresAccountID(t *testing.T) {
+	servers := newFakeServerCache()
+	servers.entries["https://api.example.com"] = authServer()
+	clients := newFakeClientStore()
+	clients.entries["https://api.example.com"] = &ClientEntry{ClientID: "client-abc"}
+	pending := newFakePendingStore()
+
+	_, err := authorizationURL(context.Background(), servers, clients, pending, testConfig(),
+		AuthorizeOptions{ServerURL: "https://api.example.com"})
+	if err == nil {
+		t.Fatal("expected error when accountID is empty")
+	}
+	if !errors.IsInvalidArgument(err) {
+		t.Errorf("expected InvalidArgument, got %v", err)
+	}
+}
+
+// Explicit options must override the config defaults.
+func TestAuthorizationURL_OptionOverrides(t *testing.T) {
+	servers := newFakeServerCache()
+	servers.entries["https://api.example.com"] = authServer()
+	clients := newFakeClientStore()
+	clients.entries["https://api.example.com"] = &ClientEntry{ClientID: "client-abc"}
+	pending := newFakePendingStore()
+
+	params, err := authorizationURL(context.Background(), servers, clients, pending, testConfig(),
+		AuthorizeOptions{
+			ServerURL:   "https://api.example.com",
+			AccountID:   "acct-1",
+			RedirectURI: "https://other/cb",
+			Scopes:      []string{"openid", "email"},
+		})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if params.RedirectURI != "https://other/cb" {
+		t.Errorf("RedirectURI = %q, want override", params.RedirectURI)
+	}
+	if params.Scope != "openid email" {
+		t.Errorf("Scope = %q, want override", params.Scope)
+	}
+}
+
+// --- HandleCallback tests ---
+
+// seedPending stores a pending state and returns its state key, mirroring what
+// AuthorizationURL would have persisted.
+func seedPending(p *fakePendingStore, state string, ps *PendingAuthState) {
+	// Mirror AuthorizationURL, which always stamps a fresh CreatedAt; without
+	// one the callback's TTL guard would treat the state as expired.
+	if ps.CreatedAt.IsZero() {
+		ps.CreatedAt = time.Now()
+	}
+	p.entries[state] = ps
+}
+
+func TestHandleCallback_SuccessfulExchange(t *testing.T) {
+	servers := newFakeServerCache()
+	servers.entries["https://api.example.com"] = authServer()
+	pending := newFakePendingStore()
+	seedPending(pending, "state-1", &PendingAuthState{
+		ServerURL:    "https://api.example.com",
+		AccountID:    "acct-1",
+		ClientID:     "client-abc",
+		CodeVerifier: "verifier-xyz",
+		RedirectURI:  "https://app.example.com/callback",
+		Scopes:       []string{"read", "write"},
+	})
+	tokens := newFakeTokenWriter()
+
+	var sentForm url.Values
+	var sawCT string
+	do := func(req *http.Request) (*http.Response, error) {
+		sawCT = req.Header.Get("Content-Type")
+		body, _ := io.ReadAll(req.Body)
+		sentForm, _ = url.ParseQuery(string(body))
+		return jsonResponse(tokenResp), nil
+	}
+
+	entry, err := handleCallback(context.Background(), do, servers, pending, tokens, "state-1", "auth-code-1")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// request shape
+	if sawCT != "application/x-www-form-urlencoded" {
+		t.Errorf("Content-Type = %q", sawCT)
+	}
+	if sentForm.Get("grant_type") != grantTypeAuthorizationCode {
+		t.Errorf("grant_type = %q", sentForm.Get("grant_type"))
+	}
+	if sentForm.Get("code") != "auth-code-1" {
+		t.Errorf("code = %q", sentForm.Get("code"))
+	}
+	if sentForm.Get("code_verifier") != "verifier-xyz" {
+		t.Errorf("code_verifier = %q", sentForm.Get("code_verifier"))
+	}
+	// client_id comes from the pending state (the client that initiated the
+	// flow), not from a fresh lookup of whatever is currently registered.
+	if sentForm.Get("client_id") != "client-abc" {
+		t.Errorf("client_id = %q", sentForm.Get("client_id"))
+	}
+	if sentForm.Get("redirect_uri") != "https://app.example.com/callback" {
+		t.Errorf("redirect_uri = %q", sentForm.Get("redirect_uri"))
+	}
+
+	// returned token
+	if entry.AccessToken != "at-123" {
+		t.Errorf("AccessToken = %q", entry.AccessToken)
+	}
+	if entry.RefreshToken != "rt-456" {
+		t.Errorf("RefreshToken = %q", entry.RefreshToken)
+	}
+	if entry.IDToken != "id-789" {
+		t.Errorf("IDToken = %q", entry.IDToken)
+	}
+	if entry.TokenType != "Bearer" {
+		t.Errorf("TokenType = %q", entry.TokenType)
+	}
+	if entry.State != SessionActive {
+		t.Errorf("State = %q, want %q", entry.State, SessionActive)
+	}
+	if entry.ExpiresAt == 0 {
+		t.Error("ExpiresAt should be derived from expires_in")
+	}
+	if strings.Join(entry.Scopes, ",") != "read,write" {
+		t.Errorf("Scopes = %v", entry.Scopes)
+	}
+
+	// persisted under {serverURL, accountId}
+	stored, ok := tokens.entries[TokenKey{ServerURL: "https://api.example.com", AccountID: "acct-1"}]
+	if !ok || stored.AccessToken != "at-123" {
+		t.Errorf("token not persisted under expected key; entries=%v", tokens.entries)
+	}
+
+	// pending state consumed
+	if pending.deletes != 1 {
+		t.Errorf("expected pending state deleted once, got %d", pending.deletes)
+	}
+	if _, exists := pending.entries["state-1"]; exists {
+		t.Error("pending state must be deleted on success")
+	}
+}
+
+func TestHandleCallback_UnknownState(t *testing.T) {
+	servers := newFakeServerCache()
+	pending := newFakePendingStore() // empty
+	tokens := newFakeTokenWriter()
+
+	do := func(req *http.Request) (*http.Response, error) {
+		t.Fatalf("network call made for unknown state: %s", req.URL)
+		return nil, nil
+	}
+
+	_, err := handleCallback(context.Background(), do, servers, pending, tokens, "missing", "code")
+	if err == nil {
+		t.Fatal("expected error for unknown/expired state")
+	}
+	if !errors.IsNotFound(err) {
+		t.Errorf("expected NotFound, got %v", err)
+	}
+	if tokens.locates != 0 {
+		t.Errorf("must not persist a token for unknown state; locates=%d", tokens.locates)
+	}
+}
+
+func TestHandleCallback_EmptyStateOrCode(t *testing.T) {
+	servers := newFakeServerCache()
+	pending := newFakePendingStore()
+	tokens := newFakeTokenWriter()
+	do := func(req *http.Request) (*http.Response, error) {
+		t.Fatalf("network call made for invalid input: %s", req.URL)
+		return nil, nil
+	}
+
+	if _, err := handleCallback(context.Background(), do, servers, pending, tokens, "", "code"); !errors.IsInvalidArgument(err) {
+		t.Errorf("empty state: expected InvalidArgument, got %v", err)
+	}
+	if _, err := handleCallback(context.Background(), do, servers, pending, tokens, "state", ""); !errors.IsInvalidArgument(err) {
+		t.Errorf("empty code: expected InvalidArgument, got %v", err)
+	}
+}
+
+// On a token-endpoint error, the pending state must survive for a retry and no
+// token may be persisted.
+func TestHandleCallback_ExchangeFailureKeepsPending(t *testing.T) {
+	servers := newFakeServerCache()
+	servers.entries["https://api.example.com"] = authServer()
+	pending := newFakePendingStore()
+	seedPending(pending, "state-1", &PendingAuthState{
+		ServerURL:    "https://api.example.com",
+		AccountID:    "acct-1",
+		ClientID:     "client-abc",
+		CodeVerifier: "verifier-xyz",
+		RedirectURI:  "https://app.example.com/callback",
+	})
+	tokens := newFakeTokenWriter()
+
+	do := func(_ *http.Request) (*http.Response, error) {
+		return statusResponse(http.StatusBadRequest), nil
+	}
+
+	_, err := handleCallback(context.Background(), do, servers, pending, tokens, "state-1", "auth-code-1")
+	if err == nil {
+		t.Fatal("expected error when token exchange fails")
+	}
+	if tokens.locates != 0 {
+		t.Errorf("must not persist a token on exchange failure; locates=%d", tokens.locates)
+	}
+	if pending.deletes != 0 {
+		t.Errorf("pending state must survive an exchange failure; deletes=%d", pending.deletes)
+	}
+	if _, ok := pending.entries["state-1"]; !ok {
+		t.Error("pending state must still exist after exchange failure")
+	}
+}
+
+// A token response without an access_token is rejected.
+func TestHandleCallback_NoAccessToken(t *testing.T) {
+	servers := newFakeServerCache()
+	servers.entries["https://api.example.com"] = authServer()
+	pending := newFakePendingStore()
+	seedPending(pending, "state-1", &PendingAuthState{
+		ServerURL:    "https://api.example.com",
+		AccountID:    "acct-1",
+		ClientID:     "client-abc",
+		CodeVerifier: "verifier-xyz",
+		RedirectURI:  "https://app.example.com/callback",
+	})
+	tokens := newFakeTokenWriter()
+
+	do := func(_ *http.Request) (*http.Response, error) {
+		return jsonResponse(`{"token_type":"Bearer","expires_in":3600}`), nil
+	}
+
+	_, err := handleCallback(context.Background(), do, servers, pending, tokens, "state-1", "auth-code-1")
+	if err == nil {
+		t.Fatal("expected error when response has no access_token")
+	}
+	if !errors.IsInvalidArgument(err) {
+		t.Errorf("expected InvalidArgument, got %v", err)
+	}
+	if tokens.locates != 0 {
+		t.Errorf("must not persist an empty token; locates=%d", tokens.locates)
+	}
+}
+
+// A pending state older than PendingStateTTL is rejected (and reaped) before any
+// token exchange, guarding against TTL-sweep lag or a store that never reaps.
+func TestHandleCallback_ExpiredPendingState(t *testing.T) {
+	servers := newFakeServerCache()
+	servers.entries["https://api.example.com"] = authServer()
+	pending := newFakePendingStore()
+	seedPending(pending, "state-1", &PendingAuthState{
+		ServerURL:    "https://api.example.com",
+		AccountID:    "acct-1",
+		ClientID:     "client-abc",
+		CodeVerifier: "verifier-xyz",
+		RedirectURI:  "https://app.example.com/callback",
+		CreatedAt:    time.Now().Add(-PendingStateTTL - time.Minute),
+	})
+	tokens := newFakeTokenWriter()
+
+	do := func(_ *http.Request) (*http.Response, error) {
+		t.Fatal("token endpoint must not be called for an expired state")
+		return nil, nil
+	}
+
+	_, err := handleCallback(context.Background(), do, servers, pending, tokens, "state-1", "auth-code-1")
+	if !errors.IsNotFound(err) {
+		t.Fatalf("expected NotFound for expired state, got %v", err)
+	}
+	if tokens.locates != 0 {
+		t.Errorf("must not persist a token for an expired state; locates=%d", tokens.locates)
+	}
+	if _, ok := pending.entries["state-1"]; ok {
+		t.Error("expired pending state must be reaped on callback")
+	}
+}
+
+// Scopes fall back to the requested scopes when the server omits them.
+func TestNewTokenEntry_ScopeFallback(t *testing.T) {
+	ps := &PendingAuthState{Scopes: []string{"read", "write"}}
+	tr := &tokenResponse{AccessToken: "at", ExpiresIn: 0}
+	entry := newTokenEntry(tr, ps, time.Now())
+	if strings.Join(entry.Scopes, ",") != "read,write" {
+		t.Errorf("Scopes = %v, want fallback to requested", entry.Scopes)
+	}
+	if entry.ExpiresAt != 0 {
+		t.Errorf("ExpiresAt = %d, want 0 when expires_in is absent", entry.ExpiresAt)
+	}
+	if entry.State != SessionActive {
+		t.Errorf("State = %q", entry.State)
+	}
+}

--- a/oauth/types.go
+++ b/oauth/types.go
@@ -113,6 +113,7 @@ type PendingAuthStateKey struct {
 type PendingAuthState struct {
 	ServerURL    string    `bson:"serverUrl"`
 	AccountID    string    `bson:"accountId"`
+	ClientID     string    `bson:"clientId"`     // client that initiated the flow
 	CodeVerifier string    `bson:"codeVerifier"` // encrypted at rest
 	RedirectURI  string    `bson:"redirectUri"`
 	Scopes       []string  `bson:"scopes,omitempty"`


### PR DESCRIPTION
## Summary

Implements the Authorization Code + PKCE flow helpers for the OAuth client library (`oauth/authorization.go`), mapping to Commit 5 of the source plan and task **AUTH-0006**.

Adds two methods on `OAuthManager`:

- `AuthorizationURL(ctx, opts)` — merges `OAuthConfig` defaults (RedirectURI, Scopes); ensures the client is registered (`GetClient`) and the server discovered (`GetCachedServer`); generates a PKCE verifier + S256 challenge and a CSRF state via `crypto/rand` (base64url, no padding, RFC 7636); persists a `PendingAuthState` (verifier encrypted at rest) keyed by the state; returns the tokenized `*AuthorizationParams` — the consumer assembles the final redirect URL. `ExtraParams` pass through verbatim.
- `HandleCallback(ctx, state, code)` — looks up the pending state by the returned CSRF state (unknown/expired → clear error), exchanges the authorization code at the token endpoint (form-encoded, presenting the stored PKCE verifier), persists the resulting `TokenEntry` (encrypted, `state=active`) keyed by `{serverURL, accountId}`, then deletes the consumed pending state.

## Design notes

- **No in-memory session** — the `state` value in the callback URL is the session handle; everything needed to complete the exchange lives in the persisted `PendingAuthState`.
- The token is persisted **before** the pending state is deleted, so a persistence failure never drops the verifier with no token to show for it; a delete failure is non-fatal (TTL index + stale-state reconciler reap it).
- The account a token is stored under is taken from the server-side `PendingAuthState` bound at `AuthorizationURL` time — never from the callback request — so a callback cannot be steered to another account. The doc comment notes the consumer must still bind the state/account to its own authenticated session (login-CSRF / session-fixation is the consumer's responsibility).

## Out of scope (deferred)

- RFC 8707 `resource` indicator is **not** forwarded to the token endpoint — matches FDP-001 §5.3 (token POST = `grant_type` + `code` + `code_verifier` + `client_id` + `redirect_uri`); `PendingAuthState` has no field to carry it. Revisit when wiring the first consumer.
- Token-endpoint error classification (transient vs `invalid_grant` vs `invalid_client`) is deferred to **AUTH-0007** (its explicit acceptance criterion; OPEN-POINTS Q5).

## Testing

- `go build ./...`, `go vet ./oauth/...`, `go test ./...`, `go test -race ./oauth/...`, and `golangci-lint run ./oauth/...` (0 issues) all pass.
- New tests cover: authorization params correctness (incl. challenge = S256(verifier) and normalized keys), per-call uniqueness of verifier/state, registered-client / discovered-server / accountID guards, option overrides, successful callback exchange (request shape + persisted token + pending deletion), unknown/empty state, exchange-failure-keeps-pending, missing access_token, and scope fallback.

Refs: AUTH-0006

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * OAuth Authorization Code flow with PKCE is now available. Includes secure parameter generation, authorization state management, automatic token exchange with proper validation, and handling of token expiration and storage.

* **Tests**
  * Comprehensive test coverage added for OAuth authorization flows and callback handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->