### PR TITLE
feat(oauth): implement token lifecycle management (AUTH-0007)

### DIFF
--- a/oauth/manager.go
+++ b/oauth/manager.go
@@ -158,12 +158,3 @@ func (m *OAuthManager) initManagerEncryptor(cfg OAuthConfig) (utils.IOEncryptor,
 func (m *OAuthManager) httpDo(req *http.Request) (*http.Response, error) {
 	return m.httpClient.Do(req)
 }
-
-// refreshToken performs the token refresh exchange with the authorization
-// server. The real RFC 6749 §6 implementation lands in AUTH-0007; until then it
-// returns errRefreshNotImplemented so the token reconciler wires through without
-// hot-looping. Both the proactive reconciler and on-demand GetToken (AUTH-0007)
-// will share this path and the token-refresh lock.
-func (m *OAuthManager) refreshToken(ctx context.Context, key *TokenKey, entry *TokenEntry) (*TokenEntry, error) {
-	return nil, errRefreshNotImplemented
-}

--- a/oauth/token.go
+++ b/oauth/token.go
@@ -1,0 +1,536 @@
+// Copyright © 2025-2026 Prabhjot Singh Sethi, All Rights reserved
+// Author: Prabhjot Singh Sethi <prabhjot.sethi@gmail.com>
+
+package oauth
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+
+	"github.com/go-core-stack/core/errors"
+	"go.mongodb.org/mongo-driver/v2/bson"
+)
+
+// Token lifecycle protocol constants.
+const (
+	grantTypeRefreshToken = "refresh_token"
+
+	// tokenTypeHintRefresh / tokenTypeHintAccess are the RFC 7009 §2.1
+	// token_type_hint values sent with a revocation request.
+	tokenTypeHintRefresh = "refresh_token"
+	tokenTypeHintAccess  = "access_token"
+
+	// OAuth error codes (RFC 6749 §5.2) that classify a refresh failure as
+	// permanent — the grant or client is no longer valid and re-authorization is
+	// required, so retrying is pointless.
+	oauthErrInvalidGrant  = "invalid_grant"
+	oauthErrInvalidClient = "invalid_client"
+)
+
+// tokenStore is the subset of the token table the lifecycle API needs. The
+// concrete *table.Table[TokenKey, TokenEntry] satisfies it; tests substitute a
+// fake so the refresh/revoke/list paths are exercised without a live MongoDB.
+type tokenStore interface {
+	Find(ctx context.Context, key *TokenKey) (*TokenEntry, error)
+	Update(ctx context.Context, key *TokenKey, entry *TokenEntry) error
+	DeleteKey(ctx context.Context, key *TokenKey) error
+	FindMany(ctx context.Context, filter any, offset, limit int32) ([]*TokenEntry, error)
+}
+
+// oauthErrorResponse is the RFC 6749 §5.2 token-endpoint error response. Parsed
+// to classify a non-2xx refresh outcome as permanent vs transient.
+type oauthErrorResponse struct {
+	ErrorCode        string `json:"error"`
+	ErrorDescription string `json:"error_description"`
+}
+
+// GetToken returns the stored token for a (server, account) pair, refreshing it
+// first if it is within the near-expiry threshold (RefreshThreshold or past
+// RefreshLifetimeFraction of its lifetime). A token that is comfortably valid is
+// returned without any network call. A revoked token is returned as-is — refresh
+// cannot resurrect it — so callers should inspect TokenEntry.State (or use
+// GetSessionState) and re-authorize when it is not active.
+func (m *OAuthManager) GetToken(ctx context.Context, serverURL, accountID string) (*TokenEntry, error) {
+	return getToken(ctx, m.tokenTable, m.tokenRefreshLocks, m.refreshToken, serverURL, accountID)
+}
+
+// RefreshToken forces a token refresh regardless of remaining lifetime, under
+// the same distributed lock the proactive reconciler uses, and returns the
+// refreshed token. A permanent failure (invalid_grant / invalid_client) marks
+// the session revoked and surfaces the error; a transient failure marks it
+// failed (keeping the existing token) and surfaces the error.
+func (m *OAuthManager) RefreshToken(ctx context.Context, serverURL, accountID string) (*TokenEntry, error) {
+	return forceRefresh(ctx, m.tokenTable, m.tokenRefreshLocks, m.refreshToken, serverURL, accountID)
+}
+
+// RevokeToken revokes the token at the server's RFC 7009 revocation endpoint and
+// marks the local session revoked. The local state transition is best-effort
+// independent of the server call: even if the server call fails (or no
+// revocation endpoint is advertised) the token is marked revoked locally, and
+// the server error is surfaced to the caller.
+func (m *OAuthManager) RevokeToken(ctx context.Context, serverURL, accountID string) error {
+	return revokeToken(ctx, m.tokenTable, m.httpDo, m.serverTable, m.clientTable, serverURL, accountID)
+}
+
+// DeleteToken removes the stored token for a (server, account) pair. It is
+// idempotent: deleting an absent token is not an error.
+func (m *OAuthManager) DeleteToken(ctx context.Context, serverURL, accountID string) error {
+	return deleteToken(ctx, m.tokenTable, serverURL, accountID)
+}
+
+// GetSessionState returns the lifecycle state of the stored token for a
+// (server, account) pair. A missing token yields a NotFound error.
+func (m *OAuthManager) GetSessionState(ctx context.Context, serverURL, accountID string) (SessionState, error) {
+	return getSessionState(ctx, m.tokenTable, serverURL, accountID)
+}
+
+// ListTokens returns all stored tokens for a server, or every stored token when
+// serverURL is empty.
+func (m *OAuthManager) ListTokens(ctx context.Context, serverURL string) ([]*TokenEntry, error) {
+	return listTokens(ctx, m.tokenTable, serverURL)
+}
+
+// refreshToken performs the token-refresh exchange (RFC 6749 §6) with the
+// authorization server and maps the outcome to a refreshed *TokenEntry or a
+// classified error (errPermanentRefresh for invalid_grant / invalid_client,
+// otherwise a transient error). It performs NO locking and NO persistence: both
+// the proactive token-refresh reconciler (AUTH-0003) and the on-demand
+// lock-guarded path (lockedRefresh) call it as the single shared exchange so
+// error classification is identical everywhere, and each owns the surrounding
+// lock and persistence. It is wired into the reconciler by NewOAuthManager.
+func (m *OAuthManager) refreshToken(ctx context.Context, key *TokenKey, entry *TokenEntry) (*TokenEntry, error) {
+	return refreshTokenExchange(ctx, m.httpDo, m.serverTable, m.clientTable, key, entry)
+}
+
+// getToken implements GetToken against the tokenStore/refreshLockerAPI/refreshFunc
+// interfaces so it is unit-testable with fakes.
+func getToken(ctx context.Context, tokens tokenStore, locks refreshLockerAPI, refresh refreshFunc, serverURL, accountID string) (*TokenEntry, error) {
+	key, err := tokenKeyFor(serverURL, accountID)
+	if err != nil {
+		return nil, err
+	}
+	entry, err := tokens.Find(ctx, key)
+	if err != nil {
+		if errors.IsNotFound(err) {
+			return nil, errors.Wrapf(errors.NotFound, "oauth: no token for %s/%s", key.ServerURL, key.AccountID)
+		}
+		return nil, err
+	}
+
+	// A revoked session cannot be refreshed back to life; hand it back as-is so
+	// the caller can detect it and re-authorize.
+	if entry.State == SessionRevoked {
+		return entry, nil
+	}
+
+	if !tokenNeedsRefresh(entry, time.Now()) {
+		return entry, nil
+	}
+	return lockedRefresh(ctx, tokens, locks, refresh, key, false)
+}
+
+// forceRefresh implements RefreshToken: a lock-guarded refresh regardless of
+// remaining lifetime.
+func forceRefresh(ctx context.Context, tokens tokenStore, locks refreshLockerAPI, refresh refreshFunc, serverURL, accountID string) (*TokenEntry, error) {
+	key, err := tokenKeyFor(serverURL, accountID)
+	if err != nil {
+		return nil, err
+	}
+	return lockedRefresh(ctx, tokens, locks, refresh, key, true)
+}
+
+// lockedRefresh is the shared on-demand refresh path used by GetToken and
+// RefreshToken. It mirrors the reconciler's lock discipline: acquire the
+// per-(server,account) token-refresh lock, re-read the token under the lock
+// (another replica or the reconciler may have refreshed it already), then run
+// the shared exchange and apply the correct session-state transition:
+//
+//	success        → persist refreshed token (state=active)
+//	invalid_grant  → state=revoked, surface the error (re-authorization required)
+//	invalid_client → state=revoked, surface the error
+//	transient err  → state=failed, keep the existing token, surface the error
+//
+// When force is false the re-read short-circuits if the token is no longer near
+// expiry, returning the fresh token without a network call.
+func lockedRefresh(ctx context.Context, tokens tokenStore, locks refreshLockerAPI, refresh refreshFunc, key *TokenKey, force bool) (*TokenEntry, error) {
+	lock, err := locks.TryAcquire(ctx, &TokenRefreshLockKey{ServerURL: key.ServerURL, AccountID: key.AccountID})
+	if err != nil {
+		return nil, errors.Wrapf(errors.GetErrCode(err),
+			"oauth: could not acquire token-refresh lock for %s/%s: %s", key.ServerURL, key.AccountID, err)
+	}
+	defer func() {
+		if cerr := lock.Close(); cerr != nil {
+			log.Printf("oauth: failed to release token-refresh lock for %s/%s: %s", key.ServerURL, key.AccountID, cerr)
+		}
+	}()
+
+	// Re-read under the lock — another instance may have refreshed already.
+	entry, err := tokens.Find(ctx, key)
+	if err != nil {
+		if errors.IsNotFound(err) {
+			return nil, errors.Wrapf(errors.NotFound, "oauth: no token for %s/%s", key.ServerURL, key.AccountID)
+		}
+		return nil, err
+	}
+	// A revoked session cannot be refreshed back to life — even a forced
+	// refresh. A concurrent RevokeToken (or a permanent failure on another
+	// replica) may have revoked it between the caller's initial read and this
+	// locked re-read; hand it back as-is so the caller re-authorizes instead of
+	// reactivating it with a still-accepted refresh token.
+	if entry.State == SessionRevoked {
+		return entry, nil
+	}
+	if !force && !tokenNeedsRefresh(entry, time.Now()) {
+		return entry, nil
+	}
+
+	updated, err := refresh(ctx, key, entry)
+	if err != nil {
+		// Classify and record the failed state, then surface the error. State
+		// persistence is best-effort: the refresh error is the caller's primary
+		// signal, so a persistence failure is logged rather than masking it.
+		if errors.Is(err, errPermanentRefresh) {
+			entry.State = SessionRevoked
+		} else {
+			entry.State = SessionFailed
+		}
+		entry.ErrorReason = err.Error()
+		if uerr := tokens.Update(ctx, key, entry); uerr != nil {
+			log.Printf("oauth: failed to persist %s state for %s/%s after refresh failure: %s",
+				entry.State, key.ServerURL, key.AccountID, uerr)
+		}
+		return nil, err
+	}
+	if updated == nil {
+		return nil, errors.Wrap(errors.Unknown, "oauth: refresh returned a nil token without an error")
+	}
+	// RevokeToken does not take this lock, so a revoke can land during the
+	// network-bound exchange above: it would read the pre-refresh active entry,
+	// revoke at the server, and persist SessionRevoked while we were waiting on
+	// the token endpoint. Re-read under the lock before persisting — if the
+	// session was revoked in that window, a still-accepted refresh token must NOT
+	// resurrect it; hand back the revoked entry and discard the refresh result.
+	if current, rerr := tokens.Find(ctx, key); rerr == nil && current.State == SessionRevoked {
+		return current, nil
+	}
+	if err := tokens.Update(ctx, key, updated); err != nil {
+		return nil, errors.Wrapf(errors.GetErrCode(err),
+			"oauth: failed to persist refreshed token for %s/%s: %s", key.ServerURL, key.AccountID, err)
+	}
+	return updated, nil
+}
+
+// refreshTokenExchange performs the RFC 6749 §6 refresh_token grant for a public
+// client and builds the refreshed TokenEntry. A missing refresh token, or an
+// invalid_grant / invalid_client response, is a permanent failure
+// (errPermanentRefresh); other failures are transient.
+func refreshTokenExchange(ctx context.Context, do httpDoFunc, servers serverCache, clients clientStore, key *TokenKey, entry *TokenEntry) (*TokenEntry, error) {
+	if strings.TrimSpace(entry.RefreshToken) == "" {
+		// No refresh token to present — the session can only be restored by a
+		// fresh authorization, so treat it as permanent.
+		return nil, fmt.Errorf("oauth: no refresh token stored for %s/%s: %w",
+			key.ServerURL, key.AccountID, errPermanentRefresh)
+	}
+
+	server, err := getCachedServer(ctx, servers, key.ServerURL)
+	if err != nil {
+		return nil, err
+	}
+	if server == nil || server.TokenEndpoint == "" {
+		return nil, errors.Wrapf(errors.InvalidArgument,
+			"oauth: server %s has no usable token endpoint", key.ServerURL)
+	}
+
+	client, err := findClient(ctx, clients, key.ServerURL)
+	if err != nil {
+		return nil, err
+	}
+	if client == nil {
+		return nil, errors.Wrapf(errors.NotFound,
+			"oauth: no registered client for %s; cannot refresh", key.ServerURL)
+	}
+
+	form := url.Values{}
+	form.Set("grant_type", grantTypeRefreshToken)
+	form.Set("refresh_token", entry.RefreshToken)
+	form.Set("client_id", client.ClientID)
+	// Deliberately omit `scope`: per RFC 6749 §6 an omitted scope means the new
+	// token keeps exactly the scope originally granted — the same result echoing
+	// the stored scopes would aim for, but without tripping authorization servers
+	// that reject an explicit scope on refresh. The granted scope is preserved
+	// from the response (or the prior entry) in refreshedTokenEntry.
+
+	tr, err := postTokenEndpoint(ctx, do, server.TokenEndpoint, form)
+	if err != nil {
+		return nil, err
+	}
+	if tr.AccessToken == "" {
+		return nil, errors.Wrapf(errors.InvalidArgument,
+			"oauth: refresh response for %s did not include an access_token", key.ServerURL)
+	}
+	return refreshedTokenEntry(entry, tr, time.Now()), nil
+}
+
+// refreshedTokenEntry builds the updated TokenEntry from a refresh response,
+// preserving prior values the server omits. Per RFC 6749 §6 the response MAY
+// omit refresh_token (the existing one stays valid); token_type and id_token are
+// likewise retained when absent. State resets to active and LastRefresh records
+// the instant for the reconciler's lifetime-fraction heuristic.
+func refreshedTokenEntry(prev *TokenEntry, tr *tokenResponse, now time.Time) *TokenEntry {
+	updated := *prev
+	updated.AccessToken = tr.AccessToken
+	if tr.TokenType != "" {
+		updated.TokenType = tr.TokenType
+	}
+	if tr.RefreshToken != "" {
+		updated.RefreshToken = tr.RefreshToken
+	}
+	if tr.IDToken != "" {
+		updated.IDToken = tr.IDToken
+	}
+	updated.Scopes = preferStrings(strings.Fields(tr.Scope), prev.Scopes)
+	updated.State = SessionActive
+	updated.ErrorReason = ""
+	updated.LastRefresh = now.Unix()
+	// Always recompute the expiry from this response. ExpiresAt is reset rather
+	// than inherited from prev: a response that omits expires_in (RFC 6749 §5.1,
+	// optional) leaves the expiry unknown, which we treat as non-expiring (no
+	// proactive refresh) — same as newTokenEntry for the initial exchange.
+	// Retaining the stale prior (now-past) expiry would make the freshly
+	// refreshed token look immediately expired and drive the reconciler into a
+	// tight re-refresh loop.
+	if tr.ExpiresIn > 0 {
+		updated.ExpiresAt = now.Add(time.Duration(tr.ExpiresIn) * time.Second).Unix()
+	} else {
+		updated.ExpiresAt = 0
+	}
+	return &updated
+}
+
+// revokeToken implements RevokeToken against the tokenStore/serverCache/
+// clientStore/httpDoFunc interfaces so it is unit-testable with fakes.
+func revokeToken(ctx context.Context, tokens tokenStore, do httpDoFunc, servers serverCache, clients clientStore, serverURL, accountID string) error {
+	key, err := tokenKeyFor(serverURL, accountID)
+	if err != nil {
+		return err
+	}
+	entry, err := tokens.Find(ctx, key)
+	if err != nil {
+		if errors.IsNotFound(err) {
+			return errors.Wrapf(errors.NotFound, "oauth: no token for %s/%s", key.ServerURL, key.AccountID)
+		}
+		return err
+	}
+
+	// Already revoked — nothing to revoke at the server and no state change to
+	// persist; return without a round-trip.
+	if entry.State == SessionRevoked {
+		return nil
+	}
+
+	// Best-effort server-side revocation; the result does not gate the local
+	// state transition.
+	serverErr := revokeAtServer(ctx, do, servers, clients, key, entry)
+
+	entry.State = SessionRevoked
+	if serverErr != nil {
+		entry.ErrorReason = serverErr.Error()
+	}
+	if uerr := tokens.Update(ctx, key, entry); uerr != nil {
+		return errors.Wrapf(errors.GetErrCode(uerr),
+			"oauth: failed to mark token revoked for %s/%s: %s", key.ServerURL, key.AccountID, uerr)
+	}
+	// Surface the server error (if any) so the caller knows server-side
+	// revocation did not complete, even though the local session is revoked.
+	return serverErr
+}
+
+// revokeAtServer POSTs an RFC 7009 revocation request, preferring the refresh
+// token (which revokes the whole grant) and falling back to the access token. A
+// server that advertises no revocation endpoint yields a clear error so the
+// caller learns the token was not revoked server-side.
+func revokeAtServer(ctx context.Context, do httpDoFunc, servers serverCache, clients clientStore, key *TokenKey, entry *TokenEntry) error {
+	server, err := getCachedServer(ctx, servers, key.ServerURL)
+	if err != nil {
+		return err
+	}
+	if server == nil || server.RevocationEndpoint == "" {
+		return errors.Wrapf(errors.InvalidArgument,
+			"oauth: server %s does not advertise a revocation endpoint", key.ServerURL)
+	}
+
+	token, hint := entry.RefreshToken, tokenTypeHintRefresh
+	if token == "" {
+		token, hint = entry.AccessToken, tokenTypeHintAccess
+	}
+	if token == "" {
+		return errors.Wrapf(errors.InvalidArgument,
+			"oauth: token for %s/%s has nothing to revoke", key.ServerURL, key.AccountID)
+	}
+
+	form := url.Values{}
+	form.Set("token", token)
+	form.Set("token_type_hint", hint)
+
+	client, err := findClient(ctx, clients, key.ServerURL)
+	if err != nil {
+		return err
+	}
+	if client != nil {
+		form.Set("client_id", client.ClientID)
+	}
+
+	return postRevocation(ctx, do, server.RevocationEndpoint, form)
+}
+
+// deleteToken implements DeleteToken: an idempotent remove (a missing entry is
+// not an error).
+func deleteToken(ctx context.Context, tokens tokenStore, serverURL, accountID string) error {
+	key, err := tokenKeyFor(serverURL, accountID)
+	if err != nil {
+		return err
+	}
+	if err := tokens.DeleteKey(ctx, key); err != nil && !errors.IsNotFound(err) {
+		return errors.Wrapf(errors.GetErrCode(err),
+			"oauth: failed to delete token for %s/%s: %s", key.ServerURL, key.AccountID, err)
+	}
+	return nil
+}
+
+// getSessionState implements GetSessionState.
+func getSessionState(ctx context.Context, tokens tokenStore, serverURL, accountID string) (SessionState, error) {
+	key, err := tokenKeyFor(serverURL, accountID)
+	if err != nil {
+		return "", err
+	}
+	entry, err := tokens.Find(ctx, key)
+	if err != nil {
+		if errors.IsNotFound(err) {
+			return "", errors.Wrapf(errors.NotFound, "oauth: no token for %s/%s", key.ServerURL, key.AccountID)
+		}
+		return "", err
+	}
+	return entry.State, nil
+}
+
+// listTokens implements ListTokens. An empty serverURL lists every token; a
+// non-empty one filters by the normalized server URL on the token key (_id). A
+// zero limit means no limit.
+func listTokens(ctx context.Context, tokens tokenStore, serverURL string) ([]*TokenEntry, error) {
+	filter := bson.M{}
+	if normalized := normalizeServerURL(serverURL); normalized != "" {
+		filter["_id.serverUrl"] = normalized
+	}
+	entries, err := tokens.FindMany(ctx, filter, 0, 0)
+	if err != nil {
+		return nil, errors.Wrapf(errors.GetErrCode(err), "oauth: failed to list tokens: %s", err)
+	}
+	return entries, nil
+}
+
+// tokenKeyFor validates the inputs and builds a normalized token key.
+func tokenKeyFor(serverURL, accountID string) (*TokenKey, error) {
+	normalized := normalizeServerURL(serverURL)
+	if normalized == "" {
+		return nil, errors.Wrap(errors.InvalidArgument, "oauth: serverURL must not be empty")
+	}
+	if strings.TrimSpace(accountID) == "" {
+		return nil, errors.Wrap(errors.InvalidArgument, "oauth: accountID must not be empty")
+	}
+	return &TokenKey{ServerURL: normalized, AccountID: accountID}, nil
+}
+
+// postTokenEndpoint POSTs a form-encoded token request and, on success, decodes
+// the JSON token response. On a non-2xx response it parses the RFC 6749 §5.2
+// error body and classifies invalid_grant / invalid_client as permanent
+// (errPermanentRefresh); every other failure is returned as a transient error.
+// The response body is bounded by maxMetadataBytes.
+func postTokenEndpoint(ctx context.Context, do httpDoFunc, endpoint string, form url.Values) (*tokenResponse, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint, strings.NewReader(form.Encode()))
+	if err != nil {
+		return nil, errors.Wrapf(errors.InvalidArgument, "oauth: failed to build request for %s: %s", endpoint, err)
+	}
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req.Header.Set("Accept", "application/json")
+
+	resp, err := do(req)
+	if err != nil {
+		return nil, errors.Wrapf(errors.Unknown, "oauth: request to %s failed: %s", endpoint, err)
+	}
+	limited := io.LimitReader(resp.Body, maxMetadataBytes)
+	defer func() {
+		_, _ = io.Copy(io.Discard, limited)
+		_ = resp.Body.Close()
+	}()
+
+	raw, err := io.ReadAll(limited)
+	if err != nil {
+		return nil, errors.Wrapf(errors.Unknown, "oauth: failed to read response from %s: %s", endpoint, err)
+	}
+
+	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
+		return nil, classifyTokenError(endpoint, resp.StatusCode, raw)
+	}
+
+	var tr tokenResponse
+	if err := json.Unmarshal(raw, &tr); err != nil {
+		return nil, errors.Wrapf(errors.InvalidArgument, "oauth: failed to parse token response from %s: %s", endpoint, err)
+	}
+	return &tr, nil
+}
+
+// classifyTokenError turns a non-2xx token-endpoint response into a permanent
+// (errPermanentRefresh) or transient error, based on the RFC 6749 §5.2 error
+// code when present.
+func classifyTokenError(endpoint string, status int, body []byte) error {
+	var oe oauthErrorResponse
+	_ = json.Unmarshal(body, &oe) // body may be empty or non-JSON; best-effort
+
+	if oe.ErrorCode == oauthErrInvalidGrant || oe.ErrorCode == oauthErrInvalidClient {
+		detail := oe.ErrorCode
+		if oe.ErrorDescription != "" {
+			detail = fmt.Sprintf("%s: %s", oe.ErrorCode, oe.ErrorDescription)
+		}
+		return fmt.Errorf("oauth: %s rejected refresh (HTTP %d, %s): %w",
+			endpoint, status, detail, errPermanentRefresh)
+	}
+
+	if oe.ErrorCode != "" {
+		return errors.Wrapf(errors.Unknown, "oauth: %s returned HTTP %d (%s)", endpoint, status, oe.ErrorCode)
+	}
+	return errors.Wrapf(errors.Unknown, "oauth: %s returned HTTP status %d", endpoint, status)
+}
+
+// postRevocation POSTs an RFC 7009 revocation request and treats any 2xx as
+// success. The endpoint returns no useful body (RFC 7009 §2.2), so the bounded
+// body is drained and discarded.
+func postRevocation(ctx context.Context, do httpDoFunc, endpoint string, form url.Values) error {
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint, strings.NewReader(form.Encode()))
+	if err != nil {
+		return errors.Wrapf(errors.InvalidArgument, "oauth: failed to build revocation request for %s: %s", endpoint, err)
+	}
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req.Header.Set("Accept", "application/json")
+
+	resp, err := do(req)
+	if err != nil {
+		return errors.Wrapf(errors.Unknown, "oauth: revocation request to %s failed: %s", endpoint, err)
+	}
+	limited := io.LimitReader(resp.Body, maxMetadataBytes)
+	defer func() {
+		_, _ = io.Copy(io.Discard, limited)
+		_ = resp.Body.Close()
+	}()
+
+	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
+		return errors.Wrapf(errors.Unknown, "oauth: %s returned HTTP status %d", endpoint, resp.StatusCode)
+	}
+	return nil
+}

--- a/oauth/token_test.go
+++ b/oauth/token_test.go
@@ -1,0 +1,677 @@
+// Copyright © 2025-2026 Prabhjot Singh Sethi, All Rights reserved
+// Author: Prabhjot Singh Sethi <prabhjot.sethi@gmail.com>
+
+package oauth
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/go-core-stack/core/errors"
+	"go.mongodb.org/mongo-driver/v2/bson"
+)
+
+// --- fakes ---
+
+// fakeTokenStore is an in-memory tokenStore recording access counts so tests can
+// assert persistence, deletion, and listing. Find returns a copy so a caller
+// mutating the result does not leak into the store before Update.
+type fakeTokenStore struct {
+	entries     map[TokenKey]*TokenEntry
+	findCalls   int
+	updateCalls int
+	deleteCalls int
+	lastFilter  any
+	deleteErr   error
+}
+
+func newFakeTokenStore() *fakeTokenStore {
+	return &fakeTokenStore{entries: map[TokenKey]*TokenEntry{}}
+}
+
+func (f *fakeTokenStore) Find(_ context.Context, key *TokenKey) (*TokenEntry, error) {
+	f.findCalls++
+	e, ok := f.entries[*key]
+	if !ok {
+		return nil, errors.Wrap(errors.NotFound, "token not found")
+	}
+	cp := *e
+	return &cp, nil
+}
+
+func (f *fakeTokenStore) Update(_ context.Context, key *TokenKey, entry *TokenEntry) error {
+	f.updateCalls++
+	cp := *entry
+	f.entries[*key] = &cp
+	return nil
+}
+
+func (f *fakeTokenStore) DeleteKey(_ context.Context, key *TokenKey) error {
+	f.deleteCalls++
+	if f.deleteErr != nil {
+		return f.deleteErr
+	}
+	if _, ok := f.entries[*key]; !ok {
+		return errors.Wrap(errors.NotFound, "token not found")
+	}
+	delete(f.entries, *key)
+	return nil
+}
+
+func (f *fakeTokenStore) FindMany(_ context.Context, filter any, _, _ int32) ([]*TokenEntry, error) {
+	f.lastFilter = filter
+	want, byServer := "", false
+	if m, ok := filter.(bson.M); ok {
+		if s, ok := m["_id.serverUrl"].(string); ok {
+			want, byServer = s, true
+		}
+	}
+	var out []*TokenEntry
+	for k, e := range f.entries {
+		if byServer && k.ServerURL != want {
+			continue
+		}
+		cp := *e
+		out = append(out, &cp)
+	}
+	return out, nil
+}
+
+// jsonStatusResponse builds a JSON HTTP response with an explicit status code.
+func jsonStatusResponse(code int, body string) *http.Response {
+	return &http.Response{
+		StatusCode: code,
+		Body:       io.NopCloser(strings.NewReader(body)),
+		Header:     http.Header{"Content-Type": []string{"application/json"}},
+	}
+}
+
+func testTokenKey() *TokenKey {
+	return &TokenKey{ServerURL: "https://api.example.com", AccountID: "acct-1"}
+}
+
+// revServer returns a discovered server with token and revocation endpoints.
+func revServer() *ServerEntry {
+	return &ServerEntry{
+		AuthorizationEndpoint: "https://as.example.com/authorize",
+		TokenEndpoint:         "https://as.example.com/token",
+		RevocationEndpoint:    "https://as.example.com/revoke",
+	}
+}
+
+// --- GetToken / RefreshToken (lock-guarded) ---
+
+func TestGetToken_HealthyReturnsAsIs(t *testing.T) {
+	tokens := newFakeTokenStore()
+	tokens.entries[*testTokenKey()] = &TokenEntry{
+		AccessToken: "at", State: SessionActive, ExpiresAt: time.Now().Add(time.Hour).Unix(),
+	}
+	locks := &fakeLocker{}
+
+	got, err := getToken(context.Background(), tokens, locks, failRefresh(t), "https://api.example.com/", "acct-1")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got.AccessToken != "at" {
+		t.Errorf("AccessToken = %q", got.AccessToken)
+	}
+	if locks.acquired != 0 {
+		t.Errorf("a healthy token must not acquire the refresh lock")
+	}
+}
+
+func TestGetToken_NearExpiryRefreshes(t *testing.T) {
+	tokens := newFakeTokenStore()
+	tokens.entries[*testTokenKey()] = &TokenEntry{
+		AccessToken: "old", RefreshToken: "rt", State: SessionActive,
+		ExpiresAt: time.Now().Add(time.Minute).Unix(), // within RefreshThreshold
+	}
+	locks := &fakeLocker{}
+	refreshed := &TokenEntry{AccessToken: "new", State: SessionActive, ExpiresAt: time.Now().Add(time.Hour).Unix()}
+	refresh := func(_ context.Context, _ *TokenKey, _ *TokenEntry) (*TokenEntry, error) { return refreshed, nil }
+
+	got, err := getToken(context.Background(), tokens, locks, refresh, "https://api.example.com", "acct-1")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got.AccessToken != "new" {
+		t.Errorf("expected refreshed token, got %q", got.AccessToken)
+	}
+	if tokens.updateCalls != 1 || tokens.entries[*testTokenKey()].AccessToken != "new" {
+		t.Errorf("refreshed token must be persisted")
+	}
+	if locks.lock == nil || !locks.lock.closed {
+		t.Errorf("refresh lock must be acquired and released")
+	}
+}
+
+func TestGetToken_NotFound(t *testing.T) {
+	tokens := newFakeTokenStore()
+	_, err := getToken(context.Background(), tokens, &fakeLocker{}, failRefresh(t), "https://api.example.com", "acct-1")
+	if !errors.IsNotFound(err) {
+		t.Fatalf("expected NotFound, got %v", err)
+	}
+}
+
+func TestGetToken_RevokedReturnedAsIs(t *testing.T) {
+	tokens := newFakeTokenStore()
+	tokens.entries[*testTokenKey()] = &TokenEntry{
+		State: SessionRevoked, ExpiresAt: time.Now().Add(-time.Hour).Unix(),
+	}
+	locks := &fakeLocker{}
+
+	got, err := getToken(context.Background(), tokens, locks, failRefresh(t), "https://api.example.com", "acct-1")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got.State != SessionRevoked {
+		t.Errorf("expected revoked token returned as-is, got %q", got.State)
+	}
+	if locks.acquired != 0 {
+		t.Errorf("a revoked token must not be refreshed")
+	}
+}
+
+func TestRefreshToken_ForcesRefreshOnHealthyToken(t *testing.T) {
+	tokens := newFakeTokenStore()
+	tokens.entries[*testTokenKey()] = &TokenEntry{
+		AccessToken: "old", State: SessionActive, ExpiresAt: time.Now().Add(time.Hour).Unix(), // healthy
+	}
+	locks := &fakeLocker{}
+	called := false
+	refresh := func(_ context.Context, _ *TokenKey, _ *TokenEntry) (*TokenEntry, error) {
+		called = true
+		return &TokenEntry{AccessToken: "new", State: SessionActive}, nil
+	}
+
+	got, err := forceRefresh(context.Background(), tokens, locks, refresh, "https://api.example.com", "acct-1")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !called {
+		t.Fatal("forced refresh must call refresh even for a healthy token")
+	}
+	if got.AccessToken != "new" || tokens.entries[*testTokenKey()].AccessToken != "new" {
+		t.Errorf("forced refresh result must be returned and persisted")
+	}
+}
+
+func TestLockedRefresh_PermanentRevokes(t *testing.T) {
+	tokens := newFakeTokenStore()
+	tokens.entries[*testTokenKey()] = &TokenEntry{AccessToken: "old", RefreshToken: "rt", State: SessionActive}
+	locks := &fakeLocker{}
+	permanent := fmt.Errorf("server said no: %w", errPermanentRefresh)
+	refresh := func(_ context.Context, _ *TokenKey, _ *TokenEntry) (*TokenEntry, error) { return nil, permanent }
+
+	_, err := lockedRefresh(context.Background(), tokens, locks, refresh, testTokenKey(), true)
+	if !errors.Is(err, errPermanentRefresh) {
+		t.Fatalf("expected permanent refresh error surfaced, got %v", err)
+	}
+	stored := tokens.entries[*testTokenKey()]
+	if stored.State != SessionRevoked || stored.ErrorReason == "" {
+		t.Errorf("permanent failure must persist revoked state with a reason, got %+v", stored)
+	}
+}
+
+func TestLockedRefresh_TransientFailsAndKeepsToken(t *testing.T) {
+	tokens := newFakeTokenStore()
+	tokens.entries[*testTokenKey()] = &TokenEntry{AccessToken: "old", RefreshToken: "rt", State: SessionActive}
+	locks := &fakeLocker{}
+	transient := errors.Wrap(errors.Unknown, "network blip")
+	refresh := func(_ context.Context, _ *TokenKey, _ *TokenEntry) (*TokenEntry, error) { return nil, transient }
+
+	_, err := lockedRefresh(context.Background(), tokens, locks, refresh, testTokenKey(), true)
+	if err == nil || errors.Is(err, errPermanentRefresh) {
+		t.Fatalf("expected a transient (non-permanent) error, got %v", err)
+	}
+	stored := tokens.entries[*testTokenKey()]
+	if stored.State != SessionFailed {
+		t.Errorf("transient failure must mark state failed, got %q", stored.State)
+	}
+	if stored.AccessToken != "old" {
+		t.Errorf("transient failure must keep the existing token, got %q", stored.AccessToken)
+	}
+}
+
+func TestLockedRefresh_LockContention(t *testing.T) {
+	tokens := newFakeTokenStore()
+	tokens.entries[*testTokenKey()] = &TokenEntry{State: SessionActive, RefreshToken: "rt"}
+	locks := &fakeLocker{acquireErr: errors.Wrap(errors.AlreadyExists, "held")}
+
+	_, err := lockedRefresh(context.Background(), tokens, locks, failRefresh(t), testTokenKey(), true)
+	if err == nil {
+		t.Fatal("expected error when the refresh lock is contended")
+	}
+}
+
+// Under the lock, a token another replica already refreshed (no longer near
+// expiry) must not be refreshed again on the non-forced path.
+func TestLockedRefresh_ConcurrentRereadSkips(t *testing.T) {
+	tokens := newFakeTokenStore()
+	tokens.entries[*testTokenKey()] = &TokenEntry{
+		AccessToken: "fresh", State: SessionActive, ExpiresAt: time.Now().Add(time.Hour).Unix(),
+	}
+	locks := &fakeLocker{}
+
+	got, err := lockedRefresh(context.Background(), tokens, locks, failRefresh(t), testTokenKey(), false)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got.AccessToken != "fresh" {
+		t.Errorf("expected the already-fresh token, got %q", got.AccessToken)
+	}
+	if locks.lock == nil || !locks.lock.closed {
+		t.Errorf("lock must still be acquired and released around the re-read")
+	}
+	if tokens.updateCalls != 0 {
+		t.Errorf("no refresh/update should occur when the re-read is fresh")
+	}
+}
+
+// A session revoked between the caller's initial read and the locked re-read
+// must not be refreshed back to life — even on the forced path — so a
+// still-accepted refresh token can't undo a local revocation.
+func TestLockedRefresh_RevokedSkipsEvenWhenForced(t *testing.T) {
+	tokens := newFakeTokenStore()
+	tokens.entries[*testTokenKey()] = &TokenEntry{
+		AccessToken: "old", RefreshToken: "rt", State: SessionRevoked,
+	}
+	locks := &fakeLocker{}
+
+	got, err := lockedRefresh(context.Background(), tokens, locks, failRefresh(t), testTokenKey(), true)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got.State != SessionRevoked {
+		t.Errorf("revoked session must be returned as-is, got state %q", got.State)
+	}
+	if tokens.updateCalls != 0 {
+		t.Errorf("revoked session must not be persisted/refreshed, got %d updates", tokens.updateCalls)
+	}
+}
+
+// A RevokeToken that lands *during* the network-bound exchange (RevokeToken does
+// not hold the refresh lock) must win: a successful refresh response arriving
+// last must not resurrect the just-revoked session. The refresh callback here
+// simulates that concurrent revoke by persisting SessionRevoked mid-exchange.
+func TestLockedRefresh_RevokeDuringExchangeWins(t *testing.T) {
+	tokens := newFakeTokenStore()
+	tokens.entries[*testTokenKey()] = &TokenEntry{
+		AccessToken: "old", RefreshToken: "rt", State: SessionActive,
+		ExpiresAt: time.Now().Add(time.Minute).Unix(), // within RefreshThreshold
+	}
+	locks := &fakeLocker{}
+	// Simulate a concurrent RevokeToken completing while the exchange is in
+	// flight, then return a successful refresh as if the token endpoint accepted
+	// the still-valid refresh token.
+	refresh := func(_ context.Context, key *TokenKey, _ *TokenEntry) (*TokenEntry, error) {
+		revoked := &TokenEntry{AccessToken: "old", RefreshToken: "rt", State: SessionRevoked}
+		if err := tokens.Update(context.Background(), key, revoked); err != nil {
+			t.Fatalf("seed revoke: %v", err)
+		}
+		return &TokenEntry{AccessToken: "new", State: SessionActive, ExpiresAt: time.Now().Add(time.Hour).Unix()}, nil
+	}
+
+	got, err := lockedRefresh(context.Background(), tokens, locks, refresh, testTokenKey(), false)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got.State != SessionRevoked {
+		t.Errorf("revoke landing mid-exchange must win, got state %q", got.State)
+	}
+	if got.AccessToken != "old" {
+		t.Errorf("refreshed token must be discarded, got %q", got.AccessToken)
+	}
+	if stored := tokens.entries[*testTokenKey()]; stored.State != SessionRevoked || stored.AccessToken != "old" {
+		t.Errorf("store must retain the revoked entry, got state %q token %q", stored.State, stored.AccessToken)
+	}
+}
+
+// --- refresh exchange + error classification ---
+
+func TestRefreshTokenExchange_Success(t *testing.T) {
+	servers := newFakeServerCache()
+	servers.entries["https://api.example.com"] = revServer()
+	clients := newFakeClientStore()
+	clients.entries["https://api.example.com"] = &ClientEntry{ClientID: "client-abc"}
+
+	var sentForm url.Values
+	do := func(req *http.Request) (*http.Response, error) {
+		body, _ := io.ReadAll(req.Body)
+		sentForm, _ = url.ParseQuery(string(body))
+		return jsonResponse(tokenResp), nil
+	}
+
+	prev := &TokenEntry{AccessToken: "old", RefreshToken: "rt-old", Scopes: []string{"read", "write"}, State: SessionFailed}
+	got, err := refreshTokenExchange(context.Background(), do, servers, clients, testTokenKey(), prev)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// request shape (RFC 6749 §6)
+	if sentForm.Get("grant_type") != grantTypeRefreshToken {
+		t.Errorf("grant_type = %q", sentForm.Get("grant_type"))
+	}
+	if sentForm.Get("refresh_token") != "rt-old" {
+		t.Errorf("refresh_token = %q", sentForm.Get("refresh_token"))
+	}
+	if sentForm.Get("client_id") != "client-abc" {
+		t.Errorf("client_id = %q", sentForm.Get("client_id"))
+	}
+	// scope is intentionally omitted on refresh (RFC 6749 §6: omitted => keep the
+	// originally granted scope) to avoid servers that reject an explicit scope.
+	if sentForm.Has("scope") {
+		t.Errorf("scope must not be sent on refresh, got %q", sentForm.Get("scope"))
+	}
+
+	// refreshed token
+	if got.AccessToken != "at-123" {
+		t.Errorf("AccessToken = %q", got.AccessToken)
+	}
+	if got.RefreshToken != "rt-456" {
+		t.Errorf("RefreshToken should update from the response, got %q", got.RefreshToken)
+	}
+	if got.State != SessionActive {
+		t.Errorf("State = %q, want active", got.State)
+	}
+	if got.ErrorReason != "" {
+		t.Errorf("ErrorReason should clear on success, got %q", got.ErrorReason)
+	}
+	if got.ExpiresAt == 0 || got.LastRefresh == 0 {
+		t.Errorf("ExpiresAt/LastRefresh must be set: %+v", got)
+	}
+}
+
+// A refresh response that omits refresh_token must retain the prior one.
+func TestRefreshTokenExchange_KeepsPriorRefreshToken(t *testing.T) {
+	servers := newFakeServerCache()
+	servers.entries["https://api.example.com"] = revServer()
+	clients := newFakeClientStore()
+	clients.entries["https://api.example.com"] = &ClientEntry{ClientID: "client-abc"}
+
+	do := func(_ *http.Request) (*http.Response, error) {
+		return jsonResponse(`{"access_token":"at-new","token_type":"Bearer","expires_in":3600}`), nil
+	}
+	prev := &TokenEntry{AccessToken: "old", RefreshToken: "rt-keep", State: SessionActive}
+	got, err := refreshTokenExchange(context.Background(), do, servers, clients, testTokenKey(), prev)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got.RefreshToken != "rt-keep" {
+		t.Errorf("expected prior refresh token retained, got %q", got.RefreshToken)
+	}
+}
+
+// A refresh response that omits expires_in must reset ExpiresAt (unknown =
+// non-expiring), not inherit the prior token's now-stale expiry — which would
+// make the refreshed token look already-expired and drive a tight re-refresh
+// loop.
+func TestRefreshTokenExchange_MissingExpiresInResetsExpiry(t *testing.T) {
+	servers := newFakeServerCache()
+	servers.entries["https://api.example.com"] = revServer()
+	clients := newFakeClientStore()
+	clients.entries["https://api.example.com"] = &ClientEntry{ClientID: "client-abc"}
+
+	do := func(_ *http.Request) (*http.Response, error) {
+		// no expires_in in the response
+		return jsonResponse(`{"access_token":"at-new","token_type":"Bearer"}`), nil
+	}
+	stalePast := time.Now().Add(-time.Hour).Unix()
+	prev := &TokenEntry{AccessToken: "old", RefreshToken: "rt", State: SessionActive, ExpiresAt: stalePast}
+
+	got, err := refreshTokenExchange(context.Background(), do, servers, clients, testTokenKey(), prev)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got.ExpiresAt != 0 {
+		t.Errorf("ExpiresAt must reset to 0 when expires_in is absent, got %d (stale prior was %d)", got.ExpiresAt, stalePast)
+	}
+	if tokenNeedsRefresh(got, time.Now()) {
+		t.Error("a refreshed token with unknown expiry must not be immediately due for refresh")
+	}
+}
+
+func TestRefreshTokenExchange_NoRefreshTokenIsPermanent(t *testing.T) {
+	servers := newFakeServerCache()
+	clients := newFakeClientStore()
+	do := func(req *http.Request) (*http.Response, error) {
+		t.Fatalf("must not call the network without a refresh token: %s", req.URL)
+		return nil, nil
+	}
+	prev := &TokenEntry{AccessToken: "old", State: SessionActive} // no RefreshToken
+	_, err := refreshTokenExchange(context.Background(), do, servers, clients, testTokenKey(), prev)
+	if !errors.Is(err, errPermanentRefresh) {
+		t.Fatalf("a missing refresh token must be a permanent failure, got %v", err)
+	}
+}
+
+func TestRefreshTokenExchange_InvalidGrantIsPermanent(t *testing.T) {
+	assertRefreshClassification(t, http.StatusBadRequest, `{"error":"invalid_grant"}`, true)
+}
+
+func TestRefreshTokenExchange_InvalidClientIsPermanent(t *testing.T) {
+	assertRefreshClassification(t, http.StatusUnauthorized, `{"error":"invalid_client","error_description":"bad client"}`, true)
+}
+
+func TestRefreshTokenExchange_TemporaryIsTransient(t *testing.T) {
+	assertRefreshClassification(t, http.StatusServiceUnavailable, `{"error":"temporarily_unavailable"}`, false)
+}
+
+func TestRefreshTokenExchange_ServerErrorIsTransient(t *testing.T) {
+	assertRefreshClassification(t, http.StatusInternalServerError, ``, false)
+}
+
+// assertRefreshClassification drives refreshTokenExchange against a token
+// endpoint that returns the given status/body and asserts whether the resulting
+// error is classified permanent (errPermanentRefresh) or transient.
+func assertRefreshClassification(t *testing.T, status int, body string, wantPermanent bool) {
+	t.Helper()
+	servers := newFakeServerCache()
+	servers.entries["https://api.example.com"] = revServer()
+	clients := newFakeClientStore()
+	clients.entries["https://api.example.com"] = &ClientEntry{ClientID: "client-abc"}
+	do := func(_ *http.Request) (*http.Response, error) { return jsonStatusResponse(status, body), nil }
+
+	prev := &TokenEntry{RefreshToken: "rt", State: SessionActive}
+	_, err := refreshTokenExchange(context.Background(), do, servers, clients, testTokenKey(), prev)
+	if err == nil {
+		t.Fatalf("expected an error for HTTP %d", status)
+	}
+	if got := errors.Is(err, errPermanentRefresh); got != wantPermanent {
+		t.Errorf("permanent=%v for HTTP %d (%q), want %v (err=%v)", got, status, body, wantPermanent, err)
+	}
+}
+
+// --- revoke ---
+
+func TestRevokeToken_Success(t *testing.T) {
+	tokens := newFakeTokenStore()
+	tokens.entries[*testTokenKey()] = &TokenEntry{AccessToken: "at", RefreshToken: "rt", State: SessionActive}
+	servers := newFakeServerCache()
+	servers.entries["https://api.example.com"] = revServer()
+	clients := newFakeClientStore()
+	clients.entries["https://api.example.com"] = &ClientEntry{ClientID: "client-abc"}
+
+	var sentForm url.Values
+	var sawURL string
+	do := func(req *http.Request) (*http.Response, error) {
+		sawURL = req.URL.String()
+		body, _ := io.ReadAll(req.Body)
+		sentForm, _ = url.ParseQuery(string(body))
+		return statusResponse(http.StatusOK), nil
+	}
+
+	if err := revokeToken(context.Background(), tokens, do, servers, clients, "https://api.example.com", "acct-1"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if sawURL != "https://as.example.com/revoke" {
+		t.Errorf("revocation posted to %q", sawURL)
+	}
+	if sentForm.Get("token") != "rt" || sentForm.Get("token_type_hint") != tokenTypeHintRefresh {
+		t.Errorf("expected refresh token revoked, form=%v", sentForm)
+	}
+	if sentForm.Get("client_id") != "client-abc" {
+		t.Errorf("client_id = %q", sentForm.Get("client_id"))
+	}
+	if tokens.entries[*testTokenKey()].State != SessionRevoked {
+		t.Errorf("token must be marked revoked locally")
+	}
+}
+
+// An already-revoked session is a no-op: no server call and no persistence
+// round-trip.
+func TestRevokeToken_AlreadyRevokedIsNoOp(t *testing.T) {
+	tokens := newFakeTokenStore()
+	tokens.entries[*testTokenKey()] = &TokenEntry{RefreshToken: "rt", State: SessionRevoked}
+	servers := newFakeServerCache()
+	servers.entries["https://api.example.com"] = revServer()
+	clients := newFakeClientStore()
+	do := func(_ *http.Request) (*http.Response, error) {
+		t.Fatal("already-revoked session must not call the server")
+		return nil, nil
+	}
+
+	if err := revokeToken(context.Background(), tokens, do, servers, clients, "https://api.example.com", "acct-1"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if tokens.updateCalls != 0 {
+		t.Errorf("already-revoked session must not persist, got %d updates", tokens.updateCalls)
+	}
+}
+
+// A failing server call must still mark the token revoked locally and surface
+// the server error.
+func TestRevokeToken_ServerFailureStillRevokesLocally(t *testing.T) {
+	tokens := newFakeTokenStore()
+	tokens.entries[*testTokenKey()] = &TokenEntry{RefreshToken: "rt", State: SessionActive}
+	servers := newFakeServerCache()
+	servers.entries["https://api.example.com"] = revServer()
+	clients := newFakeClientStore()
+	do := func(_ *http.Request) (*http.Response, error) {
+		return statusResponse(http.StatusInternalServerError), nil
+	}
+
+	err := revokeToken(context.Background(), tokens, do, servers, clients, "https://api.example.com", "acct-1")
+	if err == nil {
+		t.Fatal("expected the server error to be surfaced")
+	}
+	stored := tokens.entries[*testTokenKey()]
+	if stored.State != SessionRevoked || stored.ErrorReason == "" {
+		t.Errorf("token must be revoked locally with the server error recorded, got %+v", stored)
+	}
+}
+
+func TestRevokeToken_NoRevocationEndpoint(t *testing.T) {
+	tokens := newFakeTokenStore()
+	tokens.entries[*testTokenKey()] = &TokenEntry{RefreshToken: "rt", State: SessionActive}
+	servers := newFakeServerCache()
+	servers.entries["https://api.example.com"] = authServer() // no revocation endpoint
+	clients := newFakeClientStore()
+	do := func(req *http.Request) (*http.Response, error) {
+		t.Fatalf("must not call the network without a revocation endpoint: %s", req.URL)
+		return nil, nil
+	}
+
+	err := revokeToken(context.Background(), tokens, do, servers, clients, "https://api.example.com", "acct-1")
+	if err == nil {
+		t.Fatal("expected an error when no revocation endpoint is advertised")
+	}
+	if tokens.entries[*testTokenKey()].State != SessionRevoked {
+		t.Errorf("token must still be revoked locally")
+	}
+}
+
+func TestRevokeToken_NotFound(t *testing.T) {
+	tokens := newFakeTokenStore()
+	do := func(_ *http.Request) (*http.Response, error) { return statusResponse(http.StatusOK), nil }
+	err := revokeToken(context.Background(), tokens, do, newFakeServerCache(), newFakeClientStore(), "https://api.example.com", "acct-1")
+	if !errors.IsNotFound(err) {
+		t.Fatalf("expected NotFound for a missing token, got %v", err)
+	}
+}
+
+// --- delete / session state / list ---
+
+func TestDeleteToken_IdempotentAndRemoves(t *testing.T) {
+	tokens := newFakeTokenStore()
+	tokens.entries[*testTokenKey()] = &TokenEntry{State: SessionActive}
+
+	if err := deleteToken(context.Background(), tokens, "https://api.example.com", "acct-1"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if _, ok := tokens.entries[*testTokenKey()]; ok {
+		t.Error("token must be removed")
+	}
+	// deleting again is not an error (idempotent)
+	if err := deleteToken(context.Background(), tokens, "https://api.example.com", "acct-1"); err != nil {
+		t.Errorf("delete of a missing token must be idempotent, got %v", err)
+	}
+}
+
+func TestGetSessionState(t *testing.T) {
+	tokens := newFakeTokenStore()
+	tokens.entries[*testTokenKey()] = &TokenEntry{State: SessionFailed}
+
+	st, err := getSessionState(context.Background(), tokens, "https://api.example.com", "acct-1")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if st != SessionFailed {
+		t.Errorf("state = %q, want %q", st, SessionFailed)
+	}
+
+	if _, err := getSessionState(context.Background(), tokens, "https://api.example.com", "missing"); !errors.IsNotFound(err) {
+		t.Errorf("expected NotFound for missing token, got %v", err)
+	}
+}
+
+func TestListTokens_AllAndByServer(t *testing.T) {
+	tokens := newFakeTokenStore()
+	tokens.entries[TokenKey{ServerURL: "https://api.example.com", AccountID: "a"}] = &TokenEntry{AccessToken: "1"}
+	tokens.entries[TokenKey{ServerURL: "https://api.example.com", AccountID: "b"}] = &TokenEntry{AccessToken: "2"}
+	tokens.entries[TokenKey{ServerURL: "https://other.example.com", AccountID: "c"}] = &TokenEntry{AccessToken: "3"}
+
+	all, err := listTokens(context.Background(), tokens, "")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(all) != 3 {
+		t.Errorf("expected all 3 tokens, got %d", len(all))
+	}
+	if tokens.lastFilter == nil {
+		t.Error("expected a filter to be passed")
+	}
+
+	byServer, err := listTokens(context.Background(), tokens, "https://api.example.com/")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(byServer) != 2 {
+		t.Errorf("expected 2 tokens for the server, got %d", len(byServer))
+	}
+	if m, ok := tokens.lastFilter.(bson.M); !ok || m["_id.serverUrl"] != "https://api.example.com" {
+		t.Errorf("expected a normalized server filter, got %v", tokens.lastFilter)
+	}
+}
+
+func TestTokenKeyFor_Validation(t *testing.T) {
+	if _, err := tokenKeyFor("", "acct"); !errors.IsInvalidArgument(err) {
+		t.Errorf("empty serverURL: expected InvalidArgument, got %v", err)
+	}
+	if _, err := tokenKeyFor("https://api.example.com", "  "); !errors.IsInvalidArgument(err) {
+		t.Errorf("blank accountID: expected InvalidArgument, got %v", err)
+	}
+	key, err := tokenKeyFor("https://api.example.com/", "acct")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if key.ServerURL != "https://api.example.com" {
+		t.Errorf("serverURL not normalized: %q", key.ServerURL)
+	}
+}


### PR DESCRIPTION
## Summary

Implements the OAuth token lifecycle API (`oauth/token.go`) for the client library, mapping to Commit 6 of the source plan and task **AUTH-0007**.

Adds six methods on `OAuthManager`:

- `GetToken(ctx, serverURL, accountID)` — returns the stored token, auto-refreshing within the near-expiry threshold (RefreshThreshold or past RefreshLifetimeFraction of lifetime); a comfortably-valid token is returned with no network call, and a revoked session is returned as-is for the caller to detect and re-authorize.
- `RefreshToken(ctx, serverURL, accountID)` — forces a refresh regardless of remaining lifetime, under the same distributed lock the reconciler uses.
- `RevokeToken(ctx, serverURL, accountID)` — RFC 7009 revocation (prefers the refresh token); marks the session revoked locally even when the server call fails, and surfaces the server error.
- `DeleteToken(ctx, serverURL, accountID)` — idempotent removal.
- `GetSessionState(ctx, serverURL, accountID)` — returns the token's lifecycle state.
- `ListTokens(ctx, serverURL)` — lists tokens for a server (or all servers when empty).

## Shared, lock-guarded refresh

- The real RFC 6749 §6 refresh exchange (`refreshToken`) replaces the AUTH-0003 placeholder and stays **wired into the token-refresh reconciler** via `refresh: m.refreshToken` in `NewOAuthManager` — invoked at runtime, not dead code.
- `lockedRefresh` (used by `GetToken`/`RefreshToken`) acquires the per-`{serverURL, accountID}` token-refresh lock, re-reads under the lock (so a peer/reconciler refresh is observed), runs the shared exchange, and applies session-state transitions: success → `active`, `invalid_grant`/`invalid_client` → `revoked` (re-auth required), transient → `failed` (keeps the existing token). The exchange helper itself takes no lock, so the reconciler (which holds its own lock) and the on-demand path never stack — no deadlock.
- Refreshed/revoked tokens persist through the existing encrypted `TokenEntry` BSON marshalers.

## Notes / out of scope

- `scope` is intentionally omitted on the refresh request: per RFC 6749 §6 an omitted scope keeps exactly the originally granted scope, avoiding servers that reject an explicit scope on refresh.
- A refresh response without `expires_in` resets `ExpiresAt` to unknown (non-expiring) rather than inheriting the stale prior expiry, preventing a tight re-refresh loop.
- Error-classification refinement for non-2xx responses lacking an OAuth `error` code is deferred to OPEN-POINTS Q5 (open). `ListTokens` pagination is out of scope (the task API returns the full set).

## Testing

- `go build ./...`, `go vet ./oauth/...`, `go test ./...`, `go test -race ./oauth/...`, and `golangci-lint run ./oauth/...` (0 issues) all pass.
- New tests in `oauth/token_test.go` cover near-expiry auto-refresh, forced refresh, transient vs invalid_grant vs invalid_client classification, missing-`expires_in` expiry reset, revoke (success / server-failure / no-endpoint), delete (idempotent), session-state, listing (all / by-server), and concurrent-refresh lock behavior.

Refs: AUTH-0007

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * OAuth token management capabilities now available, including token retrieval, refresh, revocation, and deletion
  * Session state tracking for OAuth accounts
  * Token listing functionality with server filtering
  * Automatic token refresh when near expiry

* **Tests**
  * Comprehensive test coverage for OAuth token lifecycle and session management

<!-- end of auto-generated comment: release notes by coderabbit.ai -->