### PR TITLE
test(oauth): add unit tests for OAuth client library (AUTH-0008)

### DIFF
--- a/oauth/manager.go
+++ b/oauth/manager.go
@@ -61,13 +61,7 @@ func NewOAuthManager(ctx context.Context, store db.Store, cfg OAuthConfig) (*OAu
 	//    starts the background change-stream watchers (which it has no API to
 	//    unwind), shrinking the partially-initialized-watcher window.
 	pendingCol := store.GetCollection(PendingAuthStatesCollection)
-	if err := pendingCol.EnsureIndexes(ctx, []db.IndexDefinition{
-		{
-			Name:   "pending-auth-state-ttl",
-			Fields: []db.IndexField{{Field: "createdAt", IndexType: db.IndexAscending}},
-			TTL:    PendingStateTTL,
-		},
-	}); err != nil {
+	if err := pendingCol.EnsureIndexes(ctx, pendingStateTTLIndexes()); err != nil {
 		return nil, errors.Wrapf(errors.GetErrCode(err), "oauth: failed to ensure pending-auth-state TTL index: %s", err)
 	}
 
@@ -120,6 +114,22 @@ func NewOAuthManager(ctx context.Context, store db.Store, cfg OAuthConfig) (*OAu
 	}
 
 	return m, nil
+}
+
+// pendingStateTTLIndexes returns the index definitions ensured on the
+// pending_auth_states collection during initialization: a single TTL index on
+// the createdAt field that expires a pending authorization state
+// PendingStateTTL after it is created. It is a package helper (rather than an
+// inline literal) so the TTL configuration is unit-testable without a live
+// collection; NewOAuthManager ensures exactly these indexes.
+func pendingStateTTLIndexes() []db.IndexDefinition {
+	return []db.IndexDefinition{
+		{
+			Name:   "pending-auth-state-ttl",
+			Fields: []db.IndexField{{Field: "createdAt", IndexType: db.IndexAscending}},
+			TTL:    PendingStateTTL,
+		},
+	}
 }
 
 // initManagerEncryptor resolves the field-encryption key with precedence

--- a/oauth/manager_e2e_test.go
+++ b/oauth/manager_e2e_test.go
@@ -1,0 +1,289 @@
+// Copyright © 2025-2026 Prabhjot Singh Sethi, All Rights reserved
+// Author: Prabhjot Singh Sethi <prabhjot.sethi@gmail.com>
+
+package oauth
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/go-core-stack/core/errors"
+)
+
+// TestEndToEndFlow drives the full OAuth client-library lifecycle through the
+// package's own logic — discovery → registration → authorize → callback →
+// get → refresh → revoke — against a single in-memory authorization/resource
+// server (httptest, loopback only) and the shared in-memory table fakes. It is
+// hermetic: no real network and no MongoDB.
+//
+// The public *OAuthManager methods are thin one-line delegations to these same
+// internal helpers (token.go / discovery.go / registration.go / authorization.go),
+// passing the manager's concrete *table.Table fields — which cannot be faked
+// outside core/db (see manager_test.go). Wiring the helpers together here
+// exercises every step the public API runs at runtime with real HTTP round-trips.
+func TestEndToEndFlow(t *testing.T) {
+	ctx := context.Background()
+
+	// captured request artifacts, for end-to-end assertions
+	var (
+		gotAuthCode     string
+		gotCodeVerifier string
+		gotRefreshGrant bool
+		revokedToken    string
+		revokedHint     string
+	)
+
+	// srvURL is captured by the handler closures; it is only read at request
+	// time, after the server has started and srvURL has been set below.
+	var srvURL string
+
+	mux := http.NewServeMux()
+
+	// RFC 9728 protected-resource metadata: names the authorization server.
+	mux.HandleFunc(WellKnownProtectedResource, func(w http.ResponseWriter, _ *http.Request) {
+		writeJSON(t, w, map[string]any{
+			"resource":              srvURL,
+			"authorization_servers": []string{srvURL},
+			"scopes_supported":      []string{"read", "write"},
+		})
+	})
+
+	// RFC 8414 authorization-server metadata: advertises every endpoint the flow
+	// needs, all served by this same test server.
+	mux.HandleFunc(WellKnownAuthorizationServer, func(w http.ResponseWriter, _ *http.Request) {
+		writeJSON(t, w, map[string]any{
+			"issuer":                 srvURL,
+			"authorization_endpoint": srvURL + "/authorize",
+			"token_endpoint":         srvURL + "/token",
+			"revocation_endpoint":    srvURL + "/revoke",
+			"registration_endpoint":  srvURL + "/register",
+			"grant_types_supported":  []string{"authorization_code", "refresh_token"},
+		})
+	})
+
+	// RFC 7591 dynamic registration: issues a public client.
+	mux.HandleFunc("/register", func(w http.ResponseWriter, _ *http.Request) {
+		writeJSON(t, w, map[string]any{
+			"client_id":     "e2e-client",
+			"redirect_uris": []string{"https://consumer.example/callback"},
+			"scope":         "read write",
+		})
+	})
+
+	// Token endpoint: serves both the authorization-code exchange (callback) and
+	// the refresh-token grant (forced refresh), returning distinct access tokens
+	// so the refresh is observable.
+	mux.HandleFunc("/token", func(w http.ResponseWriter, r *http.Request) {
+		if err := r.ParseForm(); err != nil {
+			t.Errorf("token endpoint: parse form: %v", err)
+		}
+		switch r.Form.Get("grant_type") {
+		case grantTypeAuthorizationCode:
+			gotAuthCode = r.Form.Get("code")
+			gotCodeVerifier = r.Form.Get("code_verifier")
+			writeJSON(t, w, map[string]any{
+				"access_token":  "access-1",
+				"token_type":    "Bearer",
+				"expires_in":    3600,
+				"refresh_token": "refresh-1",
+				"scope":         "read write",
+				"id_token":      "id-1",
+			})
+		case grantTypeRefreshToken:
+			gotRefreshGrant = true
+			writeJSON(t, w, map[string]any{
+				"access_token":  "access-2",
+				"token_type":    "Bearer",
+				"expires_in":    3600,
+				"refresh_token": "refresh-2",
+				"scope":         "read write",
+			})
+		default:
+			http.Error(w, "unsupported grant_type", http.StatusBadRequest)
+		}
+	})
+
+	// RFC 7009 revocation: records what was revoked and returns 200.
+	mux.HandleFunc("/revoke", func(w http.ResponseWriter, r *http.Request) {
+		if err := r.ParseForm(); err != nil {
+			t.Errorf("revocation endpoint: parse form: %v", err)
+		}
+		revokedToken = r.Form.Get("token")
+		revokedHint = r.Form.Get("token_type_hint")
+		w.WriteHeader(http.StatusOK)
+	})
+
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+	srvURL = srv.URL
+	do := srv.Client().Do
+
+	// Shared in-memory state and a config standing in for the manager's fields.
+	servers := newFakeServerCache()
+	clients := newFakeClientStore()
+	pending := newFakePendingStore()
+	tokens := newFakeTokenStore()
+	regLocks := &fakeRegistrationLocks{}
+	refLocks := &fakeLocker{}
+	cfg := OAuthConfig{
+		RedirectURI: "https://consumer.example/callback",
+		Scopes:      []string{"read", "write"},
+		ClientName:  "e2e-test-client",
+	}
+
+	// Closures mirroring how NewOAuthManager wires DiscoverServer (used by
+	// registration) and refreshToken (used by the lifecycle refresh path) over
+	// the shared fakes and HTTP doer.
+	discover := func(ctx context.Context, serverURL string) (*ServerEntry, error) {
+		return discoverServer(ctx, do, servers, serverURL)
+	}
+	refresh := func(ctx context.Context, key *TokenKey, entry *TokenEntry) (*TokenEntry, error) {
+		return refreshTokenExchange(ctx, do, servers, clients, key, entry)
+	}
+	const accountID = "acct-1"
+
+	// 1. Discovery — RFC 9728 → RFC 8414, cached into the server table.
+	server, err := discoverServer(ctx, do, servers, srvURL)
+	if err != nil {
+		t.Fatalf("discovery: %v", err)
+	}
+	if server.TokenEndpoint != srvURL+"/token" || server.RegistrationEndpoint != srvURL+"/register" {
+		t.Fatalf("discovery did not resolve endpoints: %+v", server)
+	}
+
+	// 2. Registration — RFC 7591 dynamic, persisted to the client table.
+	client, err := registerDynamicClient(ctx, do, clients, regLocks, discover, cfg, RegisterClientOptions{ServerURL: srvURL})
+	if err != nil {
+		t.Fatalf("registration: %v", err)
+	}
+	if client.ClientID != "e2e-client" {
+		t.Fatalf("registration client_id = %q", client.ClientID)
+	}
+	if !regLocks.released() {
+		t.Error("registration lock must be released")
+	}
+
+	// 3. Authorize — PKCE params + persisted pending state.
+	params, err := authorizationURL(ctx, servers, clients, pending, cfg, AuthorizeOptions{
+		ServerURL: srvURL,
+		AccountID: accountID,
+	})
+	if err != nil {
+		t.Fatalf("authorize: %v", err)
+	}
+	if params.State == "" || params.CodeChallenge == "" || params.CodeChallengeMethod != CodeChallengeMethodS256 {
+		t.Fatalf("authorize params incomplete: %+v", params)
+	}
+	if params.ClientID != "e2e-client" || params.Endpoint != srvURL+"/authorize" {
+		t.Fatalf("authorize params not wired to discovery/registration: %+v", params)
+	}
+
+	// 4. Callback — exchange the code, persist the token, consume pending state.
+	token, err := handleCallback(ctx, do, servers, pending, tokens, params.State, "auth-code-xyz")
+	if err != nil {
+		t.Fatalf("callback: %v", err)
+	}
+	if token.AccessToken != "access-1" || token.State != SessionActive {
+		t.Fatalf("callback token = %+v", token)
+	}
+	if gotAuthCode != "auth-code-xyz" {
+		t.Errorf("token endpoint saw code %q", gotAuthCode)
+	}
+	// PKCE end-to-end: the verifier presented at the exchange must hash to the
+	// challenge handed out at authorize time.
+	if codeChallengeS256(gotCodeVerifier) != params.CodeChallenge {
+		t.Errorf("PKCE verifier does not match the issued challenge")
+	}
+	if _, err := pending.Find(ctx, &PendingAuthStateKey{State: params.State}); !errors.IsNotFound(err) {
+		t.Errorf("pending state must be consumed after callback, got %v", err)
+	}
+
+	// 5a. GetToken — a healthy (1h) token is returned without a network call or
+	// refresh-lock acquisition.
+	got, err := getToken(ctx, tokens, refLocks, refresh, srvURL, accountID)
+	if err != nil {
+		t.Fatalf("get token: %v", err)
+	}
+	if got.AccessToken != "access-1" {
+		t.Errorf("healthy GetToken = %q, want access-1", got.AccessToken)
+	}
+	if refLocks.acquired != 0 {
+		t.Errorf("healthy GetToken must not acquire the refresh lock, acquired=%d", refLocks.acquired)
+	}
+
+	// 5b. RefreshToken — forced refresh via the refresh-token grant.
+	refreshed, err := forceRefresh(ctx, tokens, refLocks, refresh, srvURL, accountID)
+	if err != nil {
+		t.Fatalf("forced refresh: %v", err)
+	}
+	if refreshed.AccessToken != "access-2" || refreshed.RefreshToken != "refresh-2" {
+		t.Fatalf("forced refresh token = %+v", refreshed)
+	}
+	if !gotRefreshGrant {
+		t.Error("token endpoint did not see a refresh_token grant")
+	}
+	if refLocks.acquired != 1 || refLocks.lock == nil || !refLocks.lock.closed {
+		t.Errorf("forced refresh must acquire and release the refresh lock (acquired=%d)", refLocks.acquired)
+	}
+
+	// 6. Revoke — RFC 7009 at the server, local session marked revoked.
+	if err := revokeToken(ctx, tokens, do, servers, clients, srvURL, accountID); err != nil {
+		t.Fatalf("revoke: %v", err)
+	}
+	if revokedToken != "refresh-2" || revokedHint != tokenTypeHintRefresh {
+		t.Errorf("revocation posted token=%q hint=%q, want the refresh token", revokedToken, revokedHint)
+	}
+
+	// 7. Session state + listing reflect the revoked, still-stored token.
+	state, err := getSessionState(ctx, tokens, srvURL, accountID)
+	if err != nil {
+		t.Fatalf("session state: %v", err)
+	}
+	if state != SessionRevoked {
+		t.Errorf("session state = %q, want revoked", state)
+	}
+	list, err := listTokens(ctx, tokens, srvURL)
+	if err != nil {
+		t.Fatalf("list tokens: %v", err)
+	}
+	if len(list) != 1 || list[0].State != SessionRevoked {
+		t.Errorf("listTokens = %+v, want one revoked token", list)
+	}
+}
+
+// TestPendingStateTTLIndexes asserts the TTL index NewOAuthManager ensures on the
+// pending_auth_states collection: a single index on createdAt expiring after
+// PendingStateTTL. This is the hermetic check for the index whose creation in
+// NewOAuthManager requires a live collection.
+func TestPendingStateTTLIndexes(t *testing.T) {
+	idx := pendingStateTTLIndexes()
+	if len(idx) != 1 {
+		t.Fatalf("expected exactly one index, got %d", len(idx))
+	}
+	def := idx[0]
+	if def.TTL != PendingStateTTL {
+		t.Errorf("TTL = %s, want %s", def.TTL, PendingStateTTL)
+	}
+	if len(def.Fields) != 1 || def.Fields[0].Field != "createdAt" {
+		t.Errorf("TTL index must be on the createdAt field, got %+v", def.Fields)
+	}
+}
+
+// writeJSON encodes v as a JSON HTTP response body for the in-memory server.
+func writeJSON(t *testing.T, w http.ResponseWriter, v any) {
+	t.Helper()
+	w.Header().Set("Content-Type", "application/json")
+	if err := json.NewEncoder(w).Encode(v); err != nil {
+		t.Errorf("encode JSON response: %v", err)
+	}
+}
+
+// compile-time guard: a single fakeTokenStore must satisfy both the lifecycle
+// tokenStore and the callback tokenWriter, as the end-to-end flow relies on.
+var (
+	_ tokenStore  = (*fakeTokenStore)(nil)
+	_ tokenWriter = (*fakeTokenStore)(nil)
+)

--- a/oauth/token_test.go
+++ b/oauth/token_test.go
@@ -64,6 +64,14 @@ func (f *fakeTokenStore) DeleteKey(_ context.Context, key *TokenKey) error {
 	return nil
 }
 
+// Locate upserts an entry, satisfying the tokenWriter interface the callback
+// handler uses. With it, one fakeTokenStore backs both the callback (which
+// persists the freshly exchanged token) and the lifecycle API (GetToken /
+// RefreshToken / RevokeToken) in the end-to-end flow test.
+func (f *fakeTokenStore) Locate(ctx context.Context, key *TokenKey, entry *TokenEntry) error {
+	return f.Update(ctx, key, entry)
+}
+
 func (f *fakeTokenStore) FindMany(_ context.Context, filter any, _, _ int32) ([]*TokenEntry, error) {
 	f.lastFilter = filter
 	want, byServer := "", false


### PR DESCRIPTION
## Summary

Closes the unit-test coverage for the OAuth client library (`oauth/` package), mapping to **Commit 7** of the source plan and task **AUTH-0008**.

Per-feature tests added during AUTH-0002..0007 already cover discovery, registration, authorization/PKCE, token lifecycle, reconcilers, and encryption round-trips. This change adds the missing **end-to-end flow test** and a hermetic **TTL-index assertion**, the two gaps that remained.

## What's added

### End-to-end flow test (`oauth/manager_e2e_test.go`)
`TestEndToEndFlow` drives the full lifecycle — **discovery → registration → authorize → callback → get → refresh → revoke** — against a single loopback `httptest` server (in-memory authorization + resource server) and the shared in-memory table fakes. No real network, no MongoDB.

It wires the package's internal helpers together exactly as `NewOAuthManager` wires them over the manager's fields (the public `*OAuthManager` methods are one-line delegations to these helpers; their concrete `*table.Table` fields can't be faked outside `core/db`, as documented in `manager_test.go`). Real HTTP round-trips exercise every step the public API runs at runtime, and the test verifies:
- PKCE end-to-end — the verifier presented at the code exchange hashes to the challenge issued at authorize time;
- the auth code is exchanged and the pending state is consumed (single-use);
- a healthy (1h) token is returned by `GetToken` without a network call or refresh-lock acquisition;
- a forced `RefreshToken` uses the refresh-token grant, rotates the access token, and acquires/releases the refresh lock;
- `RevokeToken` posts the refresh token (RFC 7009) and marks the session revoked;
- `GetSessionState` / `ListTokens` reflect the revoked, still-stored token.

### TTL-index assertion
`TestPendingStateTTLIndexes` asserts the TTL index `NewOAuthManager` ensures on `pending_auth_states`: a single index on `createdAt` expiring after `PendingStateTTL`. To make this testable without a live collection, the inline index definition is extracted into a `pendingStateTTLIndexes()` helper that `NewOAuthManager` calls (behavior-identical).

### Test fake
`fakeTokenStore` gains a `Locate` method so one fake backs both the callback writer (`tokenWriter`) and the lifecycle API (`tokenStore`) in the end-to-end test.

## Testing

`go build ./...`, `go vet ./oauth/...`, `go test ./...`, `go test -race ./oauth/...`, and `golangci-lint run ./oauth/...` (0 issues) all pass. `gofmt` clean.

Refs: AUTH-0008