### PR TITLE
feat(oauth): thread ClientRef through registration and implement static clients

### DIFF
--- a/oauth/authorization.go
+++ b/oauth/authorization.go
@@ -108,7 +108,7 @@ func authorizationURL(ctx context.Context, servers serverCache, clients clientSt
 
 	// The client must already be registered and the server already discovered:
 	// the consumer drives registration/discovery before starting a flow.
-	client, err := findClient(ctx, clients, normalized)
+	client, err := findClient(ctx, clients, normalized, merged.ClientRef)
 	if err != nil {
 		return nil, err
 	}

--- a/oauth/registration.go
+++ b/oauth/registration.go
@@ -20,16 +20,9 @@ import (
 const (
 	clientTypePublic        = "public"
 	registrationTypeDynamic = "dynamic"
+	registrationTypeStatic  = "static"
 	responseTypeCode        = "code"
 )
-
-// errStaticRegistrationUnimplemented is returned by RegisterStaticClient. Static
-// registration is interface-only in this version (see OPEN-POINTS #2); the
-// method exists so confidential/static support can land later without an API
-// change. core/errors has no dedicated "unimplemented" code, so — mirroring the
-// errRefreshNotImplemented sentinel used by the token reconciler — this is a
-// sentinel matchable with errors.Is.
-var errStaticRegistrationUnimplemented = errors.New("oauth: static client registration is not implemented (see OPEN-POINTS #2)")
 
 // clientStore is the subset of the client table that registration needs. The
 // concrete *table.Table[ClientKey, ClientEntry] satisfies it; tests substitute a
@@ -37,6 +30,9 @@ var errStaticRegistrationUnimplemented = errors.New("oauth: static client regist
 type clientStore interface {
 	Find(ctx context.Context, key *ClientKey) (*ClientEntry, error)
 	Insert(ctx context.Context, key *ClientKey, entry *ClientEntry) error
+	// Locate upserts (insert-or-update); used by static registration to
+	// (re)provision a client keyed by (ServerURL, ClientRef).
+	Locate(ctx context.Context, key *ClientKey, entry *ClientEntry) error
 	DeleteKey(ctx context.Context, key *ClientKey) error
 }
 
@@ -90,17 +86,21 @@ func (m *OAuthManager) ReRegisterClient(ctx context.Context, opts RegisterClient
 	return reRegisterClient(ctx, m.httpDo, m.clientTable, m.registrationLocks, m.DiscoverServer, m.config, opts)
 }
 
-// GetClient returns the stored client for a server, or (nil, nil) if none has
-// been registered yet. It never performs a network call.
-func (m *OAuthManager) GetClient(ctx context.Context, serverURL string) (*ClientEntry, error) {
-	return getClient(ctx, m.clientTable, serverURL)
+// GetClient returns the stored client for a (server, clientRef) pair, or
+// (nil, nil) if none has been registered yet. clientRef disambiguates multiple
+// clients registered against the same server; dynamic clients use clientRef "".
+// It never performs a network call.
+func (m *OAuthManager) GetClient(ctx context.Context, serverURL string, clientRef string) (*ClientEntry, error) {
+	return getClient(ctx, m.clientTable, serverURL, clientRef)
 }
 
-// RegisterStaticClient is the entry point for statically (pre-)provisioned
-// clients. It is interface-only in this version and always returns
-// errStaticRegistrationUnimplemented (see OPEN-POINTS #2).
-func (m *OAuthManager) RegisterStaticClient(_ context.Context, _ string, _ ClientEntry) error {
-	return errStaticRegistrationUnimplemented
+// RegisterStaticClient (pre-)provisions a confidential/static OAuth client under
+// a consumer-defined clientRef. Unlike dynamic registration it performs no
+// network call: the consumer supplies the credentials in entry, which are
+// upserted (encrypted at rest) keyed by (ServerURL, ClientRef). clientRef must
+// be non-empty — "" is reserved exclusively for the dynamic client slot.
+func (m *OAuthManager) RegisterStaticClient(ctx context.Context, serverURL string, clientRef string, entry ClientEntry) error {
+	return registerStaticClient(ctx, m.clientTable, serverURL, clientRef, entry)
 }
 
 // registerDynamicClient implements RegisterDynamicClient against the
@@ -112,10 +112,12 @@ func registerDynamicClient(ctx context.Context, do httpDoFunc, clients clientSto
 		return nil, errors.Wrap(errors.InvalidArgument, "oauth: serverURL must not be empty")
 	}
 	merged := mergeRegisterOptions(cfg, opts)
+	// clientRef disambiguates clients for the same server; dynamic uses "".
+	clientRef := opts.ClientRef
 
 	// Idempotent fast path: return an already-registered client without taking
 	// the lock or touching the network.
-	existing, err := findClient(ctx, clients, normalized)
+	existing, err := findClient(ctx, clients, normalized, clientRef)
 	if err != nil {
 		return nil, err
 	}
@@ -123,9 +125,11 @@ func registerDynamicClient(ctx context.Context, do httpDoFunc, clients clientSto
 		return existing, nil
 	}
 
-	// Serialize registration per server across replicas. TryAcquire is
-	// non-blocking: it fails when another replica currently holds the lock.
-	lock, err := locks.TryAcquire(ctx, &RegistrationLockKey{ServerURL: normalized})
+	// Serialize registration per (server, clientRef) across replicas. Keying the
+	// lock on clientRef too means static and dynamic registrations for the same
+	// server do not serialize on each other. TryAcquire is non-blocking: it
+	// fails when another replica currently holds the lock.
+	lock, err := locks.TryAcquire(ctx, &RegistrationLockKey{ServerURL: normalized, ClientRef: clientRef})
 	if err != nil {
 		// A peer is registering this server right now. It may already have
 		// finished between our fast-path miss and this acquire attempt; re-check
@@ -133,7 +137,7 @@ func registerDynamicClient(ctx context.Context, do httpDoFunc, clients clientSto
 		// registration does not surface a spurious error. If the peer is still
 		// in flight (no entry yet), surface a retryable error rather than
 		// blocking — core/sync offers no blocking acquire.
-		if existing, ferr := findClient(ctx, clients, normalized); ferr == nil && existing != nil {
+		if existing, ferr := findClient(ctx, clients, normalized, clientRef); ferr == nil && existing != nil {
 			return existing, nil
 		}
 		return nil, errors.Wrapf(errors.GetErrCode(err),
@@ -144,7 +148,7 @@ func registerDynamicClient(ctx context.Context, do httpDoFunc, clients clientSto
 
 	// Double-check inside the lock: another replica may have registered between
 	// our fast-path miss and acquiring the lock.
-	existing, err = findClient(ctx, clients, normalized)
+	existing, err = findClient(ctx, clients, normalized, clientRef)
 	if err != nil {
 		return nil, err
 	}
@@ -152,7 +156,7 @@ func registerDynamicClient(ctx context.Context, do httpDoFunc, clients clientSto
 		return existing, nil
 	}
 
-	return performRegistration(ctx, do, clients, discover, merged, normalized)
+	return performRegistration(ctx, do, clients, discover, merged, normalized, clientRef)
 }
 
 // reRegisterClient forces a fresh registration: under the per-server lock it
@@ -167,13 +171,15 @@ func reRegisterClient(ctx context.Context, do httpDoFunc, clients clientStore, l
 		return nil, errors.Wrap(errors.InvalidArgument, "oauth: serverURL must not be empty")
 	}
 	merged := mergeRegisterOptions(cfg, opts)
+	// clientRef disambiguates clients for the same server; dynamic uses "".
+	clientRef := opts.ClientRef
 
 	// Acquire the lock BEFORE the delete so the replace is atomic. Unlike the
 	// dynamic path there is no fast-path/return-existing on contention: a
 	// re-register caller wants a definitively fresh client, so on lock
 	// contention we surface a retryable error rather than another replica's
 	// (possibly the very client we were asked to replace) entry.
-	lock, err := locks.TryAcquire(ctx, &RegistrationLockKey{ServerURL: normalized})
+	lock, err := locks.TryAcquire(ctx, &RegistrationLockKey{ServerURL: normalized, ClientRef: clientRef})
 	if err != nil {
 		return nil, errors.Wrapf(errors.GetErrCode(err),
 			"oauth: registration already in progress for %s: %s", normalized, err)
@@ -181,12 +187,12 @@ func reRegisterClient(ctx context.Context, do httpDoFunc, clients clientStore, l
 	defer func() { _ = lock.Close() }()
 
 	// Delete the existing record under the lock; tolerate its absence.
-	if err := clients.DeleteKey(ctx, &ClientKey{ServerURL: normalized}); err != nil && !errors.IsNotFound(err) {
+	if err := clients.DeleteKey(ctx, &ClientKey{ServerURL: normalized, ClientRef: clientRef}); err != nil && !errors.IsNotFound(err) {
 		return nil, errors.Wrapf(errors.GetErrCode(err),
 			"oauth: failed to delete existing client for %s: %s", normalized, err)
 	}
 
-	return performRegistration(ctx, do, clients, discover, merged, normalized)
+	return performRegistration(ctx, do, clients, discover, merged, normalized, clientRef)
 }
 
 // performRegistration runs the RFC 7591 dynamic registration body for an
@@ -195,7 +201,7 @@ func reRegisterClient(ctx context.Context, do httpDoFunc, clients clientStore, l
 // the per-server registration lock and MUST have established that no client
 // should be returned from cache first (fast-path / double-check, or a delete for
 // re-registration).
-func performRegistration(ctx context.Context, do httpDoFunc, clients clientStore, discover discoverFunc, merged RegisterClientOptions, normalized string) (*ClientEntry, error) {
+func performRegistration(ctx context.Context, do httpDoFunc, clients clientStore, discover discoverFunc, merged RegisterClientOptions, normalized, clientRef string) (*ClientEntry, error) {
 	// Ensure we have server metadata, specifically the registration endpoint.
 	server, err := discover(ctx, normalized)
 	if err != nil {
@@ -239,27 +245,56 @@ func performRegistration(ctx context.Context, do httpDoFunc, clients clientStore
 	}
 
 	// Persist; sensitive fields are encrypted at rest by ClientEntry.MarshalBSON.
-	if err := clients.Insert(ctx, &ClientKey{ServerURL: normalized}, entry); err != nil {
+	if err := clients.Insert(ctx, &ClientKey{ServerURL: normalized, ClientRef: clientRef}, entry); err != nil {
 		return nil, errors.Wrapf(errors.GetErrCode(err),
 			"oauth: failed to persist registered client for %s: %s", normalized, err)
 	}
 	return entry, nil
 }
 
+// registerStaticClient implements RegisterStaticClient against the clientStore
+// interface so it is unit-testable with a fake. clientRef must be non-empty;
+// the (already consumer-supplied) entry is stamped with static metadata and
+// upserted under (ServerURL, ClientRef), encrypted at rest by
+// ClientEntry.MarshalBSON.
+func registerStaticClient(ctx context.Context, clients clientStore, serverURL, clientRef string, entry ClientEntry) error {
+	// "" is reserved exclusively for the dynamic client slot.
+	if strings.TrimSpace(clientRef) == "" {
+		return errors.Wrap(errors.InvalidArgument,
+			"oauth: clientRef must not be empty for static client registration")
+	}
+	normalized := normalizeServerURL(serverURL)
+	if normalized == "" {
+		return errors.Wrap(errors.InvalidArgument, "oauth: serverURL must not be empty")
+	}
+
+	entry.RegistrationType = registrationTypeStatic
+	entry.RegisteredAt = time.Now().Unix()
+
+	// Upsert so a static client can be re-provisioned (e.g. rotated secret)
+	// without a separate delete. Sensitive fields are encrypted at rest by
+	// ClientEntry.MarshalBSON, exactly as on the dynamic path.
+	if err := clients.Locate(ctx, &ClientKey{ServerURL: normalized, ClientRef: clientRef}, &entry); err != nil {
+		return errors.Wrapf(errors.GetErrCode(err),
+			"oauth: failed to persist static client for %s (clientRef %q): %s", normalized, clientRef, err)
+	}
+	return nil
+}
+
 // getClient implements GetClient's read-only lookup, mapping a cache miss to
 // (nil, nil).
-func getClient(ctx context.Context, clients clientStore, serverURL string) (*ClientEntry, error) {
+func getClient(ctx context.Context, clients clientStore, serverURL, clientRef string) (*ClientEntry, error) {
 	normalized := normalizeServerURL(serverURL)
 	if normalized == "" {
 		return nil, errors.Wrap(errors.InvalidArgument, "oauth: serverURL must not be empty")
 	}
-	return findClient(ctx, clients, normalized)
+	return findClient(ctx, clients, normalized, clientRef)
 }
 
-// findClient looks up a client by normalized server URL, mapping NotFound to
-// (nil, nil) and surfacing any other error.
-func findClient(ctx context.Context, clients clientStore, normalized string) (*ClientEntry, error) {
-	entry, err := clients.Find(ctx, &ClientKey{ServerURL: normalized})
+// findClient looks up a client by normalized server URL and clientRef, mapping
+// NotFound to (nil, nil) and surfacing any other error.
+func findClient(ctx context.Context, clients clientStore, normalized, clientRef string) (*ClientEntry, error) {
+	entry, err := clients.Find(ctx, &ClientKey{ServerURL: normalized, ClientRef: clientRef})
 	if err != nil {
 		if errors.IsNotFound(err) {
 			return nil, nil

--- a/oauth/registration_test.go
+++ b/oauth/registration_test.go
@@ -26,6 +26,7 @@ type fakeClientStore struct {
 	entries   map[string]*ClientEntry
 	findCalls int
 	inserts   int
+	locates   int
 	deletes   int
 	onFind    func(call int)
 }
@@ -34,12 +35,22 @@ func newFakeClientStore() *fakeClientStore {
 	return &fakeClientStore{entries: map[string]*ClientEntry{}}
 }
 
+// ckey is the map key the fake uses to model the composite (ServerURL,
+// ClientRef) primary key. An empty ClientRef (the dynamic slot) maps to the bare
+// ServerURL so existing dynamic-only tests keep indexing entries by URL.
+func ckey(serverURL, clientRef string) string {
+	if clientRef == "" {
+		return serverURL
+	}
+	return serverURL + "\x00" + clientRef
+}
+
 func (c *fakeClientStore) Find(_ context.Context, key *ClientKey) (*ClientEntry, error) {
 	c.findCalls++
 	if c.onFind != nil {
 		c.onFind(c.findCalls)
 	}
-	e, ok := c.entries[key.ServerURL]
+	e, ok := c.entries[ckey(key.ServerURL, key.ClientRef)]
 	if !ok {
 		return nil, errors.Wrapf(errors.NotFound, "no client for %s", key.ServerURL)
 	}
@@ -48,19 +59,27 @@ func (c *fakeClientStore) Find(_ context.Context, key *ClientKey) (*ClientEntry,
 
 func (c *fakeClientStore) Insert(_ context.Context, key *ClientKey, entry *ClientEntry) error {
 	c.inserts++
-	if _, ok := c.entries[key.ServerURL]; ok {
+	k := ckey(key.ServerURL, key.ClientRef)
+	if _, ok := c.entries[k]; ok {
 		return errors.Wrapf(errors.AlreadyExists, "client already exists for %s", key.ServerURL)
 	}
-	c.entries[key.ServerURL] = entry
+	c.entries[k] = entry
+	return nil
+}
+
+func (c *fakeClientStore) Locate(_ context.Context, key *ClientKey, entry *ClientEntry) error {
+	c.locates++
+	c.entries[ckey(key.ServerURL, key.ClientRef)] = entry
 	return nil
 }
 
 func (c *fakeClientStore) DeleteKey(_ context.Context, key *ClientKey) error {
 	c.deletes++
-	if _, ok := c.entries[key.ServerURL]; !ok {
+	k := ckey(key.ServerURL, key.ClientRef)
+	if _, ok := c.entries[k]; !ok {
 		return errors.Wrapf(errors.NotFound, "no client for %s", key.ServerURL)
 	}
-	delete(c.entries, key.ServerURL)
+	delete(c.entries, k)
 	return nil
 }
 
@@ -103,6 +122,10 @@ func (s *lockObservingStore) Find(ctx context.Context, key *ClientKey) (*ClientE
 
 func (s *lockObservingStore) Insert(ctx context.Context, key *ClientKey, entry *ClientEntry) error {
 	return s.store.Insert(ctx, key, entry)
+}
+
+func (s *lockObservingStore) Locate(ctx context.Context, key *ClientKey, entry *ClientEntry) error {
+	return s.store.Locate(ctx, key, entry)
 }
 
 func (s *lockObservingStore) DeleteKey(ctx context.Context, key *ClientKey) error {
@@ -502,7 +525,7 @@ func TestReRegisterClient_LockContentionFailsRetryable(t *testing.T) {
 func TestGetClient_HitAndMiss(t *testing.T) {
 	clients := newFakeClientStore()
 
-	got, err := getClient(context.Background(), clients, "https://api.example.com/")
+	got, err := getClient(context.Background(), clients, "https://api.example.com/", "")
 	if err != nil {
 		t.Fatalf("unexpected error on miss: %v", err)
 	}
@@ -511,7 +534,7 @@ func TestGetClient_HitAndMiss(t *testing.T) {
 	}
 
 	clients.entries["https://api.example.com"] = &ClientEntry{ClientID: "client-abc"}
-	got, err = getClient(context.Background(), clients, "https://api.example.com")
+	got, err = getClient(context.Background(), clients, "https://api.example.com", "")
 	if err != nil {
 		t.Fatalf("unexpected error on hit: %v", err)
 	}
@@ -520,14 +543,164 @@ func TestGetClient_HitAndMiss(t *testing.T) {
 	}
 }
 
-func TestRegisterStaticClient_Unimplemented(t *testing.T) {
-	m := &OAuthManager{}
-	err := m.RegisterStaticClient(context.Background(), "https://api.example.com", ClientEntry{})
-	if err == nil {
-		t.Fatal("expected an error from the static-registration stub")
+// GetClient must resolve by (serverURL, clientRef): looking up a clientRef that
+// was never stored is a miss even when another clientRef exists for the server.
+func TestGetClient_DistinguishesByClientRef(t *testing.T) {
+	clients := newFakeClientStore()
+	clients.entries[ckey("https://api.example.com", "tenant-a")] = &ClientEntry{ClientID: "client-a"}
+
+	got, err := getClient(context.Background(), clients, "https://api.example.com", "tenant-a")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
 	}
-	if !errors.Is(err, errStaticRegistrationUnimplemented) {
-		t.Errorf("expected errStaticRegistrationUnimplemented, got %v", err)
+	if got == nil || got.ClientID != "client-a" {
+		t.Errorf("expected tenant-a client, got %v", got)
+	}
+
+	got, err = getClient(context.Background(), clients, "https://api.example.com", "tenant-b")
+	if err != nil {
+		t.Fatalf("unexpected error on miss: %v", err)
+	}
+	if got != nil {
+		t.Errorf("expected miss for unregistered clientRef, got %v", got)
+	}
+}
+
+// Static registration must reject an empty clientRef: "" is reserved for the
+// dynamic client slot.
+func TestRegisterStaticClient_EmptyClientRefRejected(t *testing.T) {
+	clients := newFakeClientStore()
+
+	err := registerStaticClient(context.Background(), clients, "https://api.example.com", "", ClientEntry{ClientID: "x"})
+	if err == nil {
+		t.Fatal("expected an error when clientRef is empty")
+	}
+	if !errors.IsInvalidArgument(err) {
+		t.Errorf("expected InvalidArgument, got %v", err)
+	}
+	if clients.locates != 0 || clients.inserts != 0 {
+		t.Errorf("must not persist on rejection; locates=%d inserts=%d", clients.locates, clients.inserts)
+	}
+}
+
+// Static registration must reject a server URL that normalizes to empty (e.g.
+// whitespace-only): a non-empty clientRef alone is not enough to provision.
+func TestRegisterStaticClient_EmptyServerURLRejected(t *testing.T) {
+	clients := newFakeClientStore()
+
+	err := registerStaticClient(context.Background(), clients, "   ", "tenant-a", ClientEntry{ClientID: "x"})
+	if err == nil {
+		t.Fatal("expected an error when serverURL normalizes to empty")
+	}
+	if !errors.IsInvalidArgument(err) {
+		t.Errorf("expected InvalidArgument, got %v", err)
+	}
+	if clients.locates != 0 || clients.inserts != 0 {
+		t.Errorf("must not persist on rejection; locates=%d inserts=%d", clients.locates, clients.inserts)
+	}
+}
+
+// A successful static registration normalizes the server URL, stamps static
+// metadata, and upserts the consumer-supplied entry under (ServerURL, ClientRef).
+func TestRegisterStaticClient_SetsMetadataAndUpserts(t *testing.T) {
+	clients := newFakeClientStore()
+
+	// trailing slash exercises normalization on the write path
+	err := registerStaticClient(context.Background(), clients, "https://api.example.com/", "tenant-a",
+		ClientEntry{ClientID: "static-id", ClientSecret: "shh", ClientType: "confidential"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	stored := clients.entries[ckey("https://api.example.com", "tenant-a")]
+	if stored == nil {
+		t.Fatalf("client not persisted under normalized (server, clientRef) key; keys=%v", clients.entries)
+	}
+	if stored.RegistrationType != registrationTypeStatic {
+		t.Errorf("registration type = %q, want %q", stored.RegistrationType, registrationTypeStatic)
+	}
+	if stored.RegisteredAt == 0 {
+		t.Error("RegisteredAt should be set")
+	}
+	if stored.ClientType != "confidential" {
+		t.Errorf("ClientType = %q, want consumer-supplied %q", stored.ClientType, "confidential")
+	}
+	if stored.ClientID != "static-id" || stored.ClientSecret != "shh" {
+		t.Errorf("consumer-supplied credentials not preserved: %+v", stored)
+	}
+
+	// Locate is an upsert: re-registering the same ref must not error.
+	if err := registerStaticClient(context.Background(), clients, "https://api.example.com", "tenant-a",
+		ClientEntry{ClientID: "rotated", ClientSecret: "shh2", ClientType: "confidential"}); err != nil {
+		t.Fatalf("re-provisioning a static client must succeed: %v", err)
+	}
+	if got := clients.entries[ckey("https://api.example.com", "tenant-a")]; got == nil || got.ClientID != "rotated" {
+		t.Errorf("re-provision did not replace the entry; got %v", got)
+	}
+}
+
+// Two static clients for the SAME server with different clientRefs must coexist
+// independently — neither overwrites the other.
+func TestRegisterStaticClient_TwoTenantsSameServer(t *testing.T) {
+	clients := newFakeClientStore()
+	const server = "https://api.example.com"
+
+	if err := registerStaticClient(context.Background(), clients, server, "tenant-a",
+		ClientEntry{ClientID: "id-a", ClientType: "confidential"}); err != nil {
+		t.Fatalf("tenant-a registration failed: %v", err)
+	}
+	if err := registerStaticClient(context.Background(), clients, server, "tenant-b",
+		ClientEntry{ClientID: "id-b", ClientType: "confidential"}); err != nil {
+		t.Fatalf("tenant-b registration failed: %v", err)
+	}
+
+	a, err := getClient(context.Background(), clients, server, "tenant-a")
+	if err != nil || a == nil || a.ClientID != "id-a" {
+		t.Errorf("tenant-a lookup = %v, err=%v; want id-a", a, err)
+	}
+	b, err := getClient(context.Background(), clients, server, "tenant-b")
+	if err != nil || b == nil || b.ClientID != "id-b" {
+		t.Errorf("tenant-b lookup = %v, err=%v; want id-b", b, err)
+	}
+}
+
+// A static client (clientRef "tenant-a") and a dynamic client (clientRef "")
+// for the same server must not interfere with each other.
+func TestRegisterStaticClient_CoexistsWithDynamic(t *testing.T) {
+	locks := &fakeRegistrationLocks{}
+	clients := newFakeClientStore()
+	do := func(_ *http.Request) (*http.Response, error) {
+		return jsonResponse(regResp), nil
+	}
+	const server = "https://api.example.com"
+
+	// Dynamic client occupies the "" slot.
+	dyn, err := registerDynamicClient(context.Background(), do, clients, locks,
+		staticDiscover(discoveredServer()), testConfig(),
+		RegisterClientOptions{ServerURL: server})
+	if err != nil {
+		t.Fatalf("dynamic registration failed: %v", err)
+	}
+
+	// Static client for the same server under a distinct clientRef.
+	if err := registerStaticClient(context.Background(), clients, server, "tenant-a",
+		ClientEntry{ClientID: "static-id", ClientType: "confidential"}); err != nil {
+		t.Fatalf("static registration failed: %v", err)
+	}
+
+	gotDyn, err := getClient(context.Background(), clients, server, "")
+	if err != nil || gotDyn == nil || gotDyn.ClientID != dyn.ClientID {
+		t.Errorf("dynamic client clobbered: got %v err=%v, want %q", gotDyn, err, dyn.ClientID)
+	}
+	if gotDyn.RegistrationType != registrationTypeDynamic {
+		t.Errorf("dynamic slot type = %q, want %q", gotDyn.RegistrationType, registrationTypeDynamic)
+	}
+	gotStatic, err := getClient(context.Background(), clients, server, "tenant-a")
+	if err != nil || gotStatic == nil || gotStatic.ClientID != "static-id" {
+		t.Errorf("static client lookup = %v err=%v, want static-id", gotStatic, err)
+	}
+	if gotStatic.RegistrationType != registrationTypeStatic {
+		t.Errorf("static slot type = %q, want %q", gotStatic.RegistrationType, registrationTypeStatic)
 	}
 }
 

--- a/oauth/token.go
+++ b/oauth/token.go
@@ -248,7 +248,7 @@ func refreshTokenExchange(ctx context.Context, do httpDoFunc, servers serverCach
 			"oauth: server %s has no usable token endpoint", key.ServerURL)
 	}
 
-	client, err := findClient(ctx, clients, key.ServerURL)
+	client, err := findClient(ctx, clients, key.ServerURL, key.ClientRef)
 	if err != nil {
 		return nil, err
 	}
@@ -379,7 +379,7 @@ func revokeAtServer(ctx context.Context, do httpDoFunc, servers serverCache, cli
 	form.Set("token", token)
 	form.Set("token_type_hint", hint)
 
-	client, err := findClient(ctx, clients, key.ServerURL)
+	client, err := findClient(ctx, clients, key.ServerURL, key.ClientRef)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
## Summary

Implements **AUTH-0010** (Commit 2 of the OAuth Multi-Client Support proposal). Threads the consumer-defined opaque `ClientRef` through client registration and lookup, and provides the full implementation of `RegisterStaticClient` (previously a stub returning `errStaticRegistrationUnimplemented`). After this change, two clients for the same authorization server with different `ClientRef` values coexist independently.

## Changes

- **`findClient`** now accepts and uses `clientRef`, resolving clients by `(ServerURL, ClientRef)`.
- **`GetClient(ctx, serverURL, clientRef)`** — new signature; builds the composite `ClientKey`.
- **`RegisterDynamicClient` / `ReRegisterClient`** read `opts.ClientRef` and thread it through lookup, the per-server registration lock key, delete, and insert. Dynamic registration uses `ClientRef ""`; with the `omitempty` BSON tag the lock identity is unchanged, so existing dynamic serialization is preserved.
- **`RegisterStaticClient(ctx, serverURL, clientRef, entry)`** — full implementation:
  - rejects empty `clientRef` (`""` is reserved exclusively for the dynamic slot),
  - normalizes `serverURL`,
  - stamps `RegistrationType = "static"` and `RegisteredAt`,
  - upserts via `Table.Locate`, so `ClientSecret` / `RegistrationAccessToken` are encrypted at rest by `ClientEntry.MarshalBSON` (same path as dynamic).
  - Removed the now-unused `errStaticRegistrationUnimplemented` sentinel.
- **`token.go` / `authorization.go`** — updated the other `findClient` call sites for the new signature (`key.ClientRef` / `merged.ClientRef`).

## Tests

- Updated `TestGetClient_HitAndMiss` and the fake client store to model the composite `(ServerURL, ClientRef)` key (+ a `Locate` upsert).
- Replaced `TestRegisterStaticClient_Unimplemented` with positive coverage:
  1. **Two static clients, same server** (`tenant-a` / `tenant-b`) store and resolve independently.
  2. **Static + dynamic coexistence** — a dynamic client (`""`) and a static client (`tenant-a`) for one server do not interfere.
  3. **Empty `clientRef` rejected.**
  - Plus metadata/upsert and ref-distinguishing `GetClient` tests.

## Verification

- `go build ./...` ✅
- `go test -race ./oauth/...` ✅ (full suite `go test ./...` passes)
- `go vet ./oauth/`, `gofmt -l oauth/`, `golangci-lint run ./oauth/` — clean (0 issues)

Refs: AUTH-0010

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * OAuth system now supports provisioning and managing multiple distinct clients per server.
  * Static OAuth client registration is now fully implemented, enabling direct provisioning of client credentials.

* **Improvements**
  * Authorization, token refresh, and token revocation flows now correctly identify and use the appropriate client for each request based on client configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->