### PR TITLE
feat(oauth): thread ClientRef through token lifecycle and auth flow

### DIFF
--- a/oauth/authorization.go
+++ b/oauth/authorization.go
@@ -74,7 +74,8 @@ func (m *OAuthManager) AuthorizationURL(ctx context.Context, opts AuthorizeOptio
 // pending state by the returned CSRF state, exchanges the authorization code for
 // tokens at the server's token endpoint (presenting the stored PKCE verifier),
 // persists the resulting token (encrypted, state=active) keyed by
-// {serverURL, accountId}, and deletes the now-consumed pending state. An unknown
+// {serverURL, clientRef, accountId} — clientRef recovered from the pending state
+// — and deletes the now-consumed pending state. An unknown
 // or expired state yields a clear error.
 //
 // Security note: the account the token is stored under is taken from the
@@ -145,6 +146,7 @@ func authorizationURL(ctx context.Context, servers serverCache, clients clientSt
 	// lives here, so the callback needs no in-memory session.
 	ps := &PendingAuthState{
 		ServerURL:    normalized,
+		ClientRef:    merged.ClientRef,
 		AccountID:    merged.AccountID,
 		ClientID:     client.ClientID,
 		CodeVerifier: verifier,
@@ -240,10 +242,10 @@ func handleCallback(ctx context.Context, do httpDoFunc, servers serverCache, pen
 	// the state survives (TTL-bounded) for a retry, and we never drop the
 	// verifier with no token to show for it. Sensitive fields are encrypted at
 	// rest by TokenEntry.MarshalBSON.
-	tokenKey := &TokenKey{ServerURL: ps.ServerURL, AccountID: ps.AccountID}
+	tokenKey := &TokenKey{ServerURL: ps.ServerURL, ClientRef: ps.ClientRef, AccountID: ps.AccountID}
 	if err := tokens.Locate(ctx, tokenKey, entry); err != nil {
 		return nil, errors.Wrapf(errors.GetErrCode(err),
-			"oauth: failed to persist token for %s/%s: %s", ps.ServerURL, ps.AccountID, err)
+			"oauth: failed to persist token for %s: %s", tokenKey.id(), err)
 	}
 
 	// Consume the single-use pending state. The token is already durably stored,

--- a/oauth/authorization_test.go
+++ b/oauth/authorization_test.go
@@ -517,6 +517,79 @@ func TestHandleCallback_ExpiredPendingState(t *testing.T) {
 }
 
 // Scopes fall back to the requested scopes when the server omits them.
+// AuthorizationURL must thread AuthorizeOptions.ClientRef into the persisted
+// PendingAuthState so HandleCallback can rebuild the correct TokenKey, and must
+// resolve the client under the (ServerURL, ClientRef) pair.
+func TestAuthorizationURL_StoresClientRef(t *testing.T) {
+	servers := newFakeServerCache()
+	servers.entries["https://api.example.com"] = authServer()
+	clients := newFakeClientStore()
+	// Static client registered under a non-empty ClientRef.
+	clients.entries[ckey("https://api.example.com", "tenant-a")] = &ClientEntry{ClientID: "client-tenant-a"}
+	pending := newFakePendingStore()
+
+	params, err := authorizationURL(context.Background(), servers, clients, pending, testConfig(),
+		AuthorizeOptions{
+			ServerURL: "https://api.example.com/",
+			ClientRef: "tenant-a",
+			AccountID: "acct-1",
+		})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	// The client resolved must be the tenant-a static client, not the dynamic slot.
+	if params.ClientID != "client-tenant-a" {
+		t.Errorf("ClientID = %q, want client-tenant-a (resolved by ClientRef)", params.ClientID)
+	}
+	ps := pending.entries[params.State]
+	if ps == nil {
+		t.Fatalf("pending state not persisted under state %q", params.State)
+	}
+	if ps.ClientRef != "tenant-a" {
+		t.Errorf("pending ClientRef = %q, want tenant-a", ps.ClientRef)
+	}
+}
+
+// End-to-end ClientRef round-trip: an authorize started with ClientRef must
+// produce a token persisted under a TokenKey carrying that same ClientRef.
+func TestHandleCallback_ClientRefRoundTrip(t *testing.T) {
+	servers := newFakeServerCache()
+	servers.entries["https://api.example.com"] = authServer()
+	clients := newFakeClientStore()
+	clients.entries[ckey("https://api.example.com", "tenant-a")] = &ClientEntry{ClientID: "client-tenant-a"}
+	pending := newFakePendingStore()
+	tokens := newFakeTokenWriter()
+
+	params, err := authorizationURL(context.Background(), servers, clients, pending, testConfig(),
+		AuthorizeOptions{
+			ServerURL: "https://api.example.com",
+			ClientRef: "tenant-a",
+			AccountID: "acct-1",
+		})
+	if err != nil {
+		t.Fatalf("authorize: %v", err)
+	}
+
+	do := func(_ *http.Request) (*http.Response, error) { return jsonResponse(tokenResp), nil }
+	entry, err := handleCallback(context.Background(), do, servers, pending, tokens, params.State, "auth-code-1")
+	if err != nil {
+		t.Fatalf("callback: %v", err)
+	}
+	if entry.AccessToken != "at-123" {
+		t.Errorf("AccessToken = %q", entry.AccessToken)
+	}
+
+	// The token must be stored under the ClientRef-bearing key, not the dynamic
+	// (ServerURL, "", AccountID) slot.
+	want := TokenKey{ServerURL: "https://api.example.com", ClientRef: "tenant-a", AccountID: "acct-1"}
+	if _, ok := tokens.entries[want]; !ok {
+		t.Errorf("token not persisted under %+v; entries=%v", want, tokens.entries)
+	}
+	if _, ok := tokens.entries[TokenKey{ServerURL: "https://api.example.com", AccountID: "acct-1"}]; ok {
+		t.Error("token must not be stored under the dynamic (empty ClientRef) key")
+	}
+}
+
 func TestNewTokenEntry_ScopeFallback(t *testing.T) {
 	ps := &PendingAuthState{Scopes: []string{"read", "write"}}
 	tr := &tokenResponse{AccessToken: "at", ExpiresIn: 0}

--- a/oauth/manager_e2e_test.go
+++ b/oauth/manager_e2e_test.go
@@ -203,7 +203,7 @@ func TestEndToEndFlow(t *testing.T) {
 
 	// 5a. GetToken — a healthy (1h) token is returned without a network call or
 	// refresh-lock acquisition.
-	got, err := getToken(ctx, tokens, refLocks, refresh, srvURL, accountID)
+	got, err := getToken(ctx, tokens, refLocks, refresh, srvURL, "", accountID)
 	if err != nil {
 		t.Fatalf("get token: %v", err)
 	}
@@ -215,7 +215,7 @@ func TestEndToEndFlow(t *testing.T) {
 	}
 
 	// 5b. RefreshToken — forced refresh via the refresh-token grant.
-	refreshed, err := forceRefresh(ctx, tokens, refLocks, refresh, srvURL, accountID)
+	refreshed, err := forceRefresh(ctx, tokens, refLocks, refresh, srvURL, "", accountID)
 	if err != nil {
 		t.Fatalf("forced refresh: %v", err)
 	}
@@ -230,7 +230,7 @@ func TestEndToEndFlow(t *testing.T) {
 	}
 
 	// 6. Revoke — RFC 7009 at the server, local session marked revoked.
-	if err := revokeToken(ctx, tokens, do, servers, clients, srvURL, accountID); err != nil {
+	if err := revokeToken(ctx, tokens, do, servers, clients, srvURL, "", accountID); err != nil {
 		t.Fatalf("revoke: %v", err)
 	}
 	if revokedToken != "refresh-2" || revokedHint != tokenTypeHintRefresh {
@@ -238,14 +238,14 @@ func TestEndToEndFlow(t *testing.T) {
 	}
 
 	// 7. Session state + listing reflect the revoked, still-stored token.
-	state, err := getSessionState(ctx, tokens, srvURL, accountID)
+	state, err := getSessionState(ctx, tokens, srvURL, "", accountID)
 	if err != nil {
 		t.Fatalf("session state: %v", err)
 	}
 	if state != SessionRevoked {
 		t.Errorf("session state = %q, want revoked", state)
 	}
-	list, err := listTokens(ctx, tokens, srvURL)
+	list, err := listTokens(ctx, tokens, srvURL, "")
 	if err != nil {
 		t.Fatalf("list tokens: %v", err)
 	}

--- a/oauth/reconciler_test.go
+++ b/oauth/reconciler_test.go
@@ -71,10 +71,12 @@ type fakeLocker struct {
 	acquireErr error
 	lock       *fakeLock
 	acquired   int
+	lastKey    *TokenRefreshLockKey
 }
 
-func (f *fakeLocker) TryAcquire(_ context.Context, _ *TokenRefreshLockKey) (coresync.Lock, error) {
+func (f *fakeLocker) TryAcquire(_ context.Context, key *TokenRefreshLockKey) (coresync.Lock, error) {
 	f.acquired++
+	f.lastKey = key
 	if f.acquireErr != nil {
 		return nil, f.acquireErr
 	}

--- a/oauth/token.go
+++ b/oauth/token.go
@@ -57,8 +57,8 @@ type oauthErrorResponse struct {
 // returned without any network call. A revoked token is returned as-is — refresh
 // cannot resurrect it — so callers should inspect TokenEntry.State (or use
 // GetSessionState) and re-authorize when it is not active.
-func (m *OAuthManager) GetToken(ctx context.Context, serverURL, accountID string) (*TokenEntry, error) {
-	return getToken(ctx, m.tokenTable, m.tokenRefreshLocks, m.refreshToken, serverURL, accountID)
+func (m *OAuthManager) GetToken(ctx context.Context, serverURL, clientRef, accountID string) (*TokenEntry, error) {
+	return getToken(ctx, m.tokenTable, m.tokenRefreshLocks, m.refreshToken, serverURL, clientRef, accountID)
 }
 
 // RefreshToken forces a token refresh regardless of remaining lifetime, under
@@ -66,8 +66,8 @@ func (m *OAuthManager) GetToken(ctx context.Context, serverURL, accountID string
 // refreshed token. A permanent failure (invalid_grant / invalid_client) marks
 // the session revoked and surfaces the error; a transient failure marks it
 // failed (keeping the existing token) and surfaces the error.
-func (m *OAuthManager) RefreshToken(ctx context.Context, serverURL, accountID string) (*TokenEntry, error) {
-	return forceRefresh(ctx, m.tokenTable, m.tokenRefreshLocks, m.refreshToken, serverURL, accountID)
+func (m *OAuthManager) RefreshToken(ctx context.Context, serverURL, clientRef, accountID string) (*TokenEntry, error) {
+	return forceRefresh(ctx, m.tokenTable, m.tokenRefreshLocks, m.refreshToken, serverURL, clientRef, accountID)
 }
 
 // RevokeToken revokes the token at the server's RFC 7009 revocation endpoint and
@@ -75,26 +75,28 @@ func (m *OAuthManager) RefreshToken(ctx context.Context, serverURL, accountID st
 // independent of the server call: even if the server call fails (or no
 // revocation endpoint is advertised) the token is marked revoked locally, and
 // the server error is surfaced to the caller.
-func (m *OAuthManager) RevokeToken(ctx context.Context, serverURL, accountID string) error {
-	return revokeToken(ctx, m.tokenTable, m.httpDo, m.serverTable, m.clientTable, serverURL, accountID)
+func (m *OAuthManager) RevokeToken(ctx context.Context, serverURL, clientRef, accountID string) error {
+	return revokeToken(ctx, m.tokenTable, m.httpDo, m.serverTable, m.clientTable, serverURL, clientRef, accountID)
 }
 
 // DeleteToken removes the stored token for a (server, account) pair. It is
 // idempotent: deleting an absent token is not an error.
-func (m *OAuthManager) DeleteToken(ctx context.Context, serverURL, accountID string) error {
-	return deleteToken(ctx, m.tokenTable, serverURL, accountID)
+func (m *OAuthManager) DeleteToken(ctx context.Context, serverURL, clientRef, accountID string) error {
+	return deleteToken(ctx, m.tokenTable, serverURL, clientRef, accountID)
 }
 
 // GetSessionState returns the lifecycle state of the stored token for a
 // (server, account) pair. A missing token yields a NotFound error.
-func (m *OAuthManager) GetSessionState(ctx context.Context, serverURL, accountID string) (SessionState, error) {
-	return getSessionState(ctx, m.tokenTable, serverURL, accountID)
+func (m *OAuthManager) GetSessionState(ctx context.Context, serverURL, clientRef, accountID string) (SessionState, error) {
+	return getSessionState(ctx, m.tokenTable, serverURL, clientRef, accountID)
 }
 
-// ListTokens returns all stored tokens for a server, or every stored token when
-// serverURL is empty.
-func (m *OAuthManager) ListTokens(ctx context.Context, serverURL string) ([]*TokenEntry, error) {
-	return listTokens(ctx, m.tokenTable, serverURL)
+// ListTokens returns the stored tokens for a given (server, clientRef) pair. The
+// primary use case is token invalidation when a static client is removed, so the
+// listing is always scoped to a single ClientRef (dynamic callers pass ""). When
+// serverURL is empty the listing spans every server for that ClientRef.
+func (m *OAuthManager) ListTokens(ctx context.Context, serverURL string, clientRef string) ([]*TokenEntry, error) {
+	return listTokens(ctx, m.tokenTable, serverURL, clientRef)
 }
 
 // refreshToken performs the token-refresh exchange (RFC 6749 §6) with the
@@ -111,15 +113,15 @@ func (m *OAuthManager) refreshToken(ctx context.Context, key *TokenKey, entry *T
 
 // getToken implements GetToken against the tokenStore/refreshLockerAPI/refreshFunc
 // interfaces so it is unit-testable with fakes.
-func getToken(ctx context.Context, tokens tokenStore, locks refreshLockerAPI, refresh refreshFunc, serverURL, accountID string) (*TokenEntry, error) {
-	key, err := tokenKeyFor(serverURL, accountID)
+func getToken(ctx context.Context, tokens tokenStore, locks refreshLockerAPI, refresh refreshFunc, serverURL, clientRef, accountID string) (*TokenEntry, error) {
+	key, err := tokenKeyFor(serverURL, clientRef, accountID)
 	if err != nil {
 		return nil, err
 	}
 	entry, err := tokens.Find(ctx, key)
 	if err != nil {
 		if errors.IsNotFound(err) {
-			return nil, errors.Wrapf(errors.NotFound, "oauth: no token for %s/%s", key.ServerURL, key.AccountID)
+			return nil, errors.Wrapf(errors.NotFound, "oauth: no token for %s", key.id())
 		}
 		return nil, err
 	}
@@ -138,8 +140,8 @@ func getToken(ctx context.Context, tokens tokenStore, locks refreshLockerAPI, re
 
 // forceRefresh implements RefreshToken: a lock-guarded refresh regardless of
 // remaining lifetime.
-func forceRefresh(ctx context.Context, tokens tokenStore, locks refreshLockerAPI, refresh refreshFunc, serverURL, accountID string) (*TokenEntry, error) {
-	key, err := tokenKeyFor(serverURL, accountID)
+func forceRefresh(ctx context.Context, tokens tokenStore, locks refreshLockerAPI, refresh refreshFunc, serverURL, clientRef, accountID string) (*TokenEntry, error) {
+	key, err := tokenKeyFor(serverURL, clientRef, accountID)
 	if err != nil {
 		return nil, err
 	}
@@ -160,14 +162,14 @@ func forceRefresh(ctx context.Context, tokens tokenStore, locks refreshLockerAPI
 // When force is false the re-read short-circuits if the token is no longer near
 // expiry, returning the fresh token without a network call.
 func lockedRefresh(ctx context.Context, tokens tokenStore, locks refreshLockerAPI, refresh refreshFunc, key *TokenKey, force bool) (*TokenEntry, error) {
-	lock, err := locks.TryAcquire(ctx, &TokenRefreshLockKey{ServerURL: key.ServerURL, AccountID: key.AccountID})
+	lock, err := locks.TryAcquire(ctx, &TokenRefreshLockKey{ServerURL: key.ServerURL, ClientRef: key.ClientRef, AccountID: key.AccountID})
 	if err != nil {
 		return nil, errors.Wrapf(errors.GetErrCode(err),
-			"oauth: could not acquire token-refresh lock for %s/%s: %s", key.ServerURL, key.AccountID, err)
+			"oauth: could not acquire token-refresh lock for %s: %s", key.id(), err)
 	}
 	defer func() {
 		if cerr := lock.Close(); cerr != nil {
-			log.Printf("oauth: failed to release token-refresh lock for %s/%s: %s", key.ServerURL, key.AccountID, cerr)
+			log.Printf("oauth: failed to release token-refresh lock for %s: %s", key.id(), cerr)
 		}
 	}()
 
@@ -175,7 +177,7 @@ func lockedRefresh(ctx context.Context, tokens tokenStore, locks refreshLockerAP
 	entry, err := tokens.Find(ctx, key)
 	if err != nil {
 		if errors.IsNotFound(err) {
-			return nil, errors.Wrapf(errors.NotFound, "oauth: no token for %s/%s", key.ServerURL, key.AccountID)
+			return nil, errors.Wrapf(errors.NotFound, "oauth: no token for %s", key.id())
 		}
 		return nil, err
 	}
@@ -203,8 +205,8 @@ func lockedRefresh(ctx context.Context, tokens tokenStore, locks refreshLockerAP
 		}
 		entry.ErrorReason = err.Error()
 		if uerr := tokens.Update(ctx, key, entry); uerr != nil {
-			log.Printf("oauth: failed to persist %s state for %s/%s after refresh failure: %s",
-				entry.State, key.ServerURL, key.AccountID, uerr)
+			log.Printf("oauth: failed to persist %s state for %s after refresh failure: %s",
+				entry.State, key.id(), uerr)
 		}
 		return nil, err
 	}
@@ -222,7 +224,7 @@ func lockedRefresh(ctx context.Context, tokens tokenStore, locks refreshLockerAP
 	}
 	if err := tokens.Update(ctx, key, updated); err != nil {
 		return nil, errors.Wrapf(errors.GetErrCode(err),
-			"oauth: failed to persist refreshed token for %s/%s: %s", key.ServerURL, key.AccountID, err)
+			"oauth: failed to persist refreshed token for %s: %s", key.id(), err)
 	}
 	return updated, nil
 }
@@ -235,8 +237,8 @@ func refreshTokenExchange(ctx context.Context, do httpDoFunc, servers serverCach
 	if strings.TrimSpace(entry.RefreshToken) == "" {
 		// No refresh token to present — the session can only be restored by a
 		// fresh authorization, so treat it as permanent.
-		return nil, fmt.Errorf("oauth: no refresh token stored for %s/%s: %w",
-			key.ServerURL, key.AccountID, errPermanentRefresh)
+		return nil, fmt.Errorf("oauth: no refresh token stored for %s: %w",
+			key.id(), errPermanentRefresh)
 	}
 
 	server, err := getCachedServer(ctx, servers, key.ServerURL)
@@ -316,15 +318,15 @@ func refreshedTokenEntry(prev *TokenEntry, tr *tokenResponse, now time.Time) *To
 
 // revokeToken implements RevokeToken against the tokenStore/serverCache/
 // clientStore/httpDoFunc interfaces so it is unit-testable with fakes.
-func revokeToken(ctx context.Context, tokens tokenStore, do httpDoFunc, servers serverCache, clients clientStore, serverURL, accountID string) error {
-	key, err := tokenKeyFor(serverURL, accountID)
+func revokeToken(ctx context.Context, tokens tokenStore, do httpDoFunc, servers serverCache, clients clientStore, serverURL, clientRef, accountID string) error {
+	key, err := tokenKeyFor(serverURL, clientRef, accountID)
 	if err != nil {
 		return err
 	}
 	entry, err := tokens.Find(ctx, key)
 	if err != nil {
 		if errors.IsNotFound(err) {
-			return errors.Wrapf(errors.NotFound, "oauth: no token for %s/%s", key.ServerURL, key.AccountID)
+			return errors.Wrapf(errors.NotFound, "oauth: no token for %s", key.id())
 		}
 		return err
 	}
@@ -345,7 +347,7 @@ func revokeToken(ctx context.Context, tokens tokenStore, do httpDoFunc, servers 
 	}
 	if uerr := tokens.Update(ctx, key, entry); uerr != nil {
 		return errors.Wrapf(errors.GetErrCode(uerr),
-			"oauth: failed to mark token revoked for %s/%s: %s", key.ServerURL, key.AccountID, uerr)
+			"oauth: failed to mark token revoked for %s: %s", key.id(), uerr)
 	}
 	// Surface the server error (if any) so the caller knows server-side
 	// revocation did not complete, even though the local session is revoked.
@@ -372,7 +374,7 @@ func revokeAtServer(ctx context.Context, do httpDoFunc, servers serverCache, cli
 	}
 	if token == "" {
 		return errors.Wrapf(errors.InvalidArgument,
-			"oauth: token for %s/%s has nothing to revoke", key.ServerURL, key.AccountID)
+			"oauth: token for %s has nothing to revoke", key.id())
 	}
 
 	form := url.Values{}
@@ -392,39 +394,41 @@ func revokeAtServer(ctx context.Context, do httpDoFunc, servers serverCache, cli
 
 // deleteToken implements DeleteToken: an idempotent remove (a missing entry is
 // not an error).
-func deleteToken(ctx context.Context, tokens tokenStore, serverURL, accountID string) error {
-	key, err := tokenKeyFor(serverURL, accountID)
+func deleteToken(ctx context.Context, tokens tokenStore, serverURL, clientRef, accountID string) error {
+	key, err := tokenKeyFor(serverURL, clientRef, accountID)
 	if err != nil {
 		return err
 	}
 	if err := tokens.DeleteKey(ctx, key); err != nil && !errors.IsNotFound(err) {
 		return errors.Wrapf(errors.GetErrCode(err),
-			"oauth: failed to delete token for %s/%s: %s", key.ServerURL, key.AccountID, err)
+			"oauth: failed to delete token for %s: %s", key.id(), err)
 	}
 	return nil
 }
 
 // getSessionState implements GetSessionState.
-func getSessionState(ctx context.Context, tokens tokenStore, serverURL, accountID string) (SessionState, error) {
-	key, err := tokenKeyFor(serverURL, accountID)
+func getSessionState(ctx context.Context, tokens tokenStore, serverURL, clientRef, accountID string) (SessionState, error) {
+	key, err := tokenKeyFor(serverURL, clientRef, accountID)
 	if err != nil {
 		return "", err
 	}
 	entry, err := tokens.Find(ctx, key)
 	if err != nil {
 		if errors.IsNotFound(err) {
-			return "", errors.Wrapf(errors.NotFound, "oauth: no token for %s/%s", key.ServerURL, key.AccountID)
+			return "", errors.Wrapf(errors.NotFound, "oauth: no token for %s", key.id())
 		}
 		return "", err
 	}
 	return entry.State, nil
 }
 
-// listTokens implements ListTokens. An empty serverURL lists every token; a
-// non-empty one filters by the normalized server URL on the token key (_id). A
-// zero limit means no limit.
-func listTokens(ctx context.Context, tokens tokenStore, serverURL string) ([]*TokenEntry, error) {
-	filter := bson.M{}
+// listTokens implements ListTokens. The listing is scoped to a single clientRef
+// on the token key (_id): an empty serverURL spans every server for that
+// clientRef, a non-empty one also filters by the normalized server URL. A zero
+// limit means no limit. (Final filter scoping for the dynamic "" clientRef is
+// finalized in AUTH-0012.)
+func listTokens(ctx context.Context, tokens tokenStore, serverURL string, clientRef string) ([]*TokenEntry, error) {
+	filter := bson.M{"_id.clientRef": clientRef}
 	if normalized := normalizeServerURL(serverURL); normalized != "" {
 		filter["_id.serverUrl"] = normalized
 	}
@@ -435,8 +439,11 @@ func listTokens(ctx context.Context, tokens tokenStore, serverURL string) ([]*To
 	return entries, nil
 }
 
-// tokenKeyFor validates the inputs and builds a normalized token key.
-func tokenKeyFor(serverURL, accountID string) (*TokenKey, error) {
+// tokenKeyFor validates the inputs and builds a normalized token key. clientRef
+// is the consumer-defined opaque label disambiguating multiple clients for the
+// same server; dynamic registration passes "" (omitted from the stored key by
+// the omitempty BSON tag).
+func tokenKeyFor(serverURL, clientRef, accountID string) (*TokenKey, error) {
 	normalized := normalizeServerURL(serverURL)
 	if normalized == "" {
 		return nil, errors.Wrap(errors.InvalidArgument, "oauth: serverURL must not be empty")
@@ -444,7 +451,16 @@ func tokenKeyFor(serverURL, accountID string) (*TokenKey, error) {
 	if strings.TrimSpace(accountID) == "" {
 		return nil, errors.Wrap(errors.InvalidArgument, "oauth: accountID must not be empty")
 	}
-	return &TokenKey{ServerURL: normalized, AccountID: accountID}, nil
+	return &TokenKey{ServerURL: normalized, ClientRef: clientRef, AccountID: accountID}, nil
+}
+
+// id renders the token key as a human-readable identity for diagnostics:
+// "serverURL/clientRef/accountID". A dynamic client's empty ClientRef renders as
+// an empty middle segment ("serverURL//accountID"), which unambiguously signals
+// the dynamic slot and disambiguates the message once multiple clients can share
+// a (server, account) pair.
+func (k *TokenKey) id() string {
+	return fmt.Sprintf("%s/%s/%s", k.ServerURL, k.ClientRef, k.AccountID)
 }
 
 // postTokenEndpoint POSTs a form-encoded token request and, on success, decodes

--- a/oauth/token_test.go
+++ b/oauth/token_test.go
@@ -75,14 +75,21 @@ func (f *fakeTokenStore) Locate(ctx context.Context, key *TokenKey, entry *Token
 func (f *fakeTokenStore) FindMany(_ context.Context, filter any, _, _ int32) ([]*TokenEntry, error) {
 	f.lastFilter = filter
 	want, byServer := "", false
+	wantRef, byRef := "", false
 	if m, ok := filter.(bson.M); ok {
 		if s, ok := m["_id.serverUrl"].(string); ok {
 			want, byServer = s, true
+		}
+		if s, ok := m["_id.clientRef"].(string); ok {
+			wantRef, byRef = s, true
 		}
 	}
 	var out []*TokenEntry
 	for k, e := range f.entries {
 		if byServer && k.ServerURL != want {
+			continue
+		}
+		if byRef && k.ClientRef != wantRef {
 			continue
 		}
 		cp := *e
@@ -122,7 +129,7 @@ func TestGetToken_HealthyReturnsAsIs(t *testing.T) {
 	}
 	locks := &fakeLocker{}
 
-	got, err := getToken(context.Background(), tokens, locks, failRefresh(t), "https://api.example.com/", "acct-1")
+	got, err := getToken(context.Background(), tokens, locks, failRefresh(t), "https://api.example.com/", "", "acct-1")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -144,7 +151,7 @@ func TestGetToken_NearExpiryRefreshes(t *testing.T) {
 	refreshed := &TokenEntry{AccessToken: "new", State: SessionActive, ExpiresAt: time.Now().Add(time.Hour).Unix()}
 	refresh := func(_ context.Context, _ *TokenKey, _ *TokenEntry) (*TokenEntry, error) { return refreshed, nil }
 
-	got, err := getToken(context.Background(), tokens, locks, refresh, "https://api.example.com", "acct-1")
+	got, err := getToken(context.Background(), tokens, locks, refresh, "https://api.example.com", "", "acct-1")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -161,7 +168,7 @@ func TestGetToken_NearExpiryRefreshes(t *testing.T) {
 
 func TestGetToken_NotFound(t *testing.T) {
 	tokens := newFakeTokenStore()
-	_, err := getToken(context.Background(), tokens, &fakeLocker{}, failRefresh(t), "https://api.example.com", "acct-1")
+	_, err := getToken(context.Background(), tokens, &fakeLocker{}, failRefresh(t), "https://api.example.com", "", "acct-1")
 	if !errors.IsNotFound(err) {
 		t.Fatalf("expected NotFound, got %v", err)
 	}
@@ -174,7 +181,7 @@ func TestGetToken_RevokedReturnedAsIs(t *testing.T) {
 	}
 	locks := &fakeLocker{}
 
-	got, err := getToken(context.Background(), tokens, locks, failRefresh(t), "https://api.example.com", "acct-1")
+	got, err := getToken(context.Background(), tokens, locks, failRefresh(t), "https://api.example.com", "", "acct-1")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -183,6 +190,35 @@ func TestGetToken_RevokedReturnedAsIs(t *testing.T) {
 	}
 	if locks.acquired != 0 {
 		t.Errorf("a revoked token must not be refreshed")
+	}
+}
+
+// Tokens for the same (server, account) but different ClientRef values are
+// stored and retrieved independently: the dynamic slot ("") and a static client
+// ("tenant-a") must not collide.
+func TestGetToken_ClientRefIsolation(t *testing.T) {
+	tokens := newFakeTokenStore()
+	hour := time.Now().Add(time.Hour).Unix()
+	tokens.entries[TokenKey{ServerURL: "https://api.example.com", AccountID: "user1"}] =
+		&TokenEntry{AccessToken: "dynamic-tok", State: SessionActive, ExpiresAt: hour}
+	tokens.entries[TokenKey{ServerURL: "https://api.example.com", ClientRef: "tenant-a", AccountID: "user1"}] =
+		&TokenEntry{AccessToken: "tenant-a-tok", State: SessionActive, ExpiresAt: hour}
+	locks := &fakeLocker{}
+
+	dyn, err := getToken(context.Background(), tokens, locks, failRefresh(t), "https://api.example.com", "", "user1")
+	if err != nil {
+		t.Fatalf("dynamic GetToken: %v", err)
+	}
+	if dyn.AccessToken != "dynamic-tok" {
+		t.Errorf("dynamic token = %q, want dynamic-tok", dyn.AccessToken)
+	}
+
+	static, err := getToken(context.Background(), tokens, locks, failRefresh(t), "https://api.example.com", "tenant-a", "user1")
+	if err != nil {
+		t.Fatalf("tenant-a GetToken: %v", err)
+	}
+	if static.AccessToken != "tenant-a-tok" {
+		t.Errorf("tenant-a token = %q, want tenant-a-tok", static.AccessToken)
 	}
 }
 
@@ -198,7 +234,7 @@ func TestRefreshToken_ForcesRefreshOnHealthyToken(t *testing.T) {
 		return &TokenEntry{AccessToken: "new", State: SessionActive}, nil
 	}
 
-	got, err := forceRefresh(context.Background(), tokens, locks, refresh, "https://api.example.com", "acct-1")
+	got, err := forceRefresh(context.Background(), tokens, locks, refresh, "https://api.example.com", "", "acct-1")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -515,7 +551,7 @@ func TestRevokeToken_Success(t *testing.T) {
 		return statusResponse(http.StatusOK), nil
 	}
 
-	if err := revokeToken(context.Background(), tokens, do, servers, clients, "https://api.example.com", "acct-1"); err != nil {
+	if err := revokeToken(context.Background(), tokens, do, servers, clients, "https://api.example.com", "", "acct-1"); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	if sawURL != "https://as.example.com/revoke" {
@@ -545,7 +581,7 @@ func TestRevokeToken_AlreadyRevokedIsNoOp(t *testing.T) {
 		return nil, nil
 	}
 
-	if err := revokeToken(context.Background(), tokens, do, servers, clients, "https://api.example.com", "acct-1"); err != nil {
+	if err := revokeToken(context.Background(), tokens, do, servers, clients, "https://api.example.com", "", "acct-1"); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	if tokens.updateCalls != 0 {
@@ -565,7 +601,7 @@ func TestRevokeToken_ServerFailureStillRevokesLocally(t *testing.T) {
 		return statusResponse(http.StatusInternalServerError), nil
 	}
 
-	err := revokeToken(context.Background(), tokens, do, servers, clients, "https://api.example.com", "acct-1")
+	err := revokeToken(context.Background(), tokens, do, servers, clients, "https://api.example.com", "", "acct-1")
 	if err == nil {
 		t.Fatal("expected the server error to be surfaced")
 	}
@@ -586,7 +622,7 @@ func TestRevokeToken_NoRevocationEndpoint(t *testing.T) {
 		return nil, nil
 	}
 
-	err := revokeToken(context.Background(), tokens, do, servers, clients, "https://api.example.com", "acct-1")
+	err := revokeToken(context.Background(), tokens, do, servers, clients, "https://api.example.com", "", "acct-1")
 	if err == nil {
 		t.Fatal("expected an error when no revocation endpoint is advertised")
 	}
@@ -598,7 +634,7 @@ func TestRevokeToken_NoRevocationEndpoint(t *testing.T) {
 func TestRevokeToken_NotFound(t *testing.T) {
 	tokens := newFakeTokenStore()
 	do := func(_ *http.Request) (*http.Response, error) { return statusResponse(http.StatusOK), nil }
-	err := revokeToken(context.Background(), tokens, do, newFakeServerCache(), newFakeClientStore(), "https://api.example.com", "acct-1")
+	err := revokeToken(context.Background(), tokens, do, newFakeServerCache(), newFakeClientStore(), "https://api.example.com", "", "acct-1")
 	if !errors.IsNotFound(err) {
 		t.Fatalf("expected NotFound for a missing token, got %v", err)
 	}
@@ -610,14 +646,14 @@ func TestDeleteToken_IdempotentAndRemoves(t *testing.T) {
 	tokens := newFakeTokenStore()
 	tokens.entries[*testTokenKey()] = &TokenEntry{State: SessionActive}
 
-	if err := deleteToken(context.Background(), tokens, "https://api.example.com", "acct-1"); err != nil {
+	if err := deleteToken(context.Background(), tokens, "https://api.example.com", "", "acct-1"); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	if _, ok := tokens.entries[*testTokenKey()]; ok {
 		t.Error("token must be removed")
 	}
 	// deleting again is not an error (idempotent)
-	if err := deleteToken(context.Background(), tokens, "https://api.example.com", "acct-1"); err != nil {
+	if err := deleteToken(context.Background(), tokens, "https://api.example.com", "", "acct-1"); err != nil {
 		t.Errorf("delete of a missing token must be idempotent, got %v", err)
 	}
 }
@@ -626,7 +662,7 @@ func TestGetSessionState(t *testing.T) {
 	tokens := newFakeTokenStore()
 	tokens.entries[*testTokenKey()] = &TokenEntry{State: SessionFailed}
 
-	st, err := getSessionState(context.Background(), tokens, "https://api.example.com", "acct-1")
+	st, err := getSessionState(context.Background(), tokens, "https://api.example.com", "", "acct-1")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -634,7 +670,7 @@ func TestGetSessionState(t *testing.T) {
 		t.Errorf("state = %q, want %q", st, SessionFailed)
 	}
 
-	if _, err := getSessionState(context.Background(), tokens, "https://api.example.com", "missing"); !errors.IsNotFound(err) {
+	if _, err := getSessionState(context.Background(), tokens, "https://api.example.com", "", "missing"); !errors.IsNotFound(err) {
 		t.Errorf("expected NotFound for missing token, got %v", err)
 	}
 }
@@ -645,7 +681,7 @@ func TestListTokens_AllAndByServer(t *testing.T) {
 	tokens.entries[TokenKey{ServerURL: "https://api.example.com", AccountID: "b"}] = &TokenEntry{AccessToken: "2"}
 	tokens.entries[TokenKey{ServerURL: "https://other.example.com", AccountID: "c"}] = &TokenEntry{AccessToken: "3"}
 
-	all, err := listTokens(context.Background(), tokens, "")
+	all, err := listTokens(context.Background(), tokens, "", "")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -656,7 +692,7 @@ func TestListTokens_AllAndByServer(t *testing.T) {
 		t.Error("expected a filter to be passed")
 	}
 
-	byServer, err := listTokens(context.Background(), tokens, "https://api.example.com/")
+	byServer, err := listTokens(context.Background(), tokens, "https://api.example.com/", "")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -669,17 +705,115 @@ func TestListTokens_AllAndByServer(t *testing.T) {
 }
 
 func TestTokenKeyFor_Validation(t *testing.T) {
-	if _, err := tokenKeyFor("", "acct"); !errors.IsInvalidArgument(err) {
+	if _, err := tokenKeyFor("", "", "acct"); !errors.IsInvalidArgument(err) {
 		t.Errorf("empty serverURL: expected InvalidArgument, got %v", err)
 	}
-	if _, err := tokenKeyFor("https://api.example.com", "  "); !errors.IsInvalidArgument(err) {
+	if _, err := tokenKeyFor("https://api.example.com", "", "  "); !errors.IsInvalidArgument(err) {
 		t.Errorf("blank accountID: expected InvalidArgument, got %v", err)
 	}
-	key, err := tokenKeyFor("https://api.example.com/", "acct")
+	key, err := tokenKeyFor("https://api.example.com/", "", "acct")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	if key.ServerURL != "https://api.example.com" {
 		t.Errorf("serverURL not normalized: %q", key.ServerURL)
+	}
+}
+
+// tokenKeyFor must carry a non-empty clientRef through into the key.
+func TestTokenKeyFor_ClientRef(t *testing.T) {
+	key, err := tokenKeyFor("https://api.example.com", "tenant-a", "acct")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if key.ClientRef != "tenant-a" {
+		t.Errorf("ClientRef = %q, want tenant-a", key.ClientRef)
+	}
+}
+
+// A forced refresh on a token stored under a non-empty ClientRef must acquire
+// the refresh lock under a key that carries that same ClientRef, so static and
+// dynamic refreshes for one (server, account) do not serialize on each other.
+func TestForceRefresh_LockKeyCarriesClientRef(t *testing.T) {
+	tokens := newFakeTokenStore()
+	tokens.entries[TokenKey{ServerURL: "https://api.example.com", ClientRef: "tenant-a", AccountID: "acct-1"}] =
+		&TokenEntry{AccessToken: "old", RefreshToken: "rt", State: SessionActive}
+	locks := &fakeLocker{}
+	refresh := func(_ context.Context, _ *TokenKey, _ *TokenEntry) (*TokenEntry, error) {
+		return &TokenEntry{AccessToken: "new", State: SessionActive}, nil
+	}
+
+	if _, err := forceRefresh(context.Background(), tokens, locks, refresh, "https://api.example.com", "tenant-a", "acct-1"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if locks.lastKey == nil {
+		t.Fatal("expected the refresh lock to be acquired")
+	}
+	if locks.lastKey.ClientRef != "tenant-a" {
+		t.Errorf("lock key ClientRef = %q, want tenant-a", locks.lastKey.ClientRef)
+	}
+	if locks.lastKey.ServerURL != "https://api.example.com" || locks.lastKey.AccountID != "acct-1" {
+		t.Errorf("lock key = %+v, want server/account preserved", locks.lastKey)
+	}
+}
+
+// Revoke, session-state, and delete must all operate on the ClientRef-scoped key
+// and leave a same-(server,account) token under a different ClientRef untouched.
+func TestTokenLifecycle_WithClientRef(t *testing.T) {
+	tokens := newFakeTokenStore()
+	refKey := TokenKey{ServerURL: "https://api.example.com", ClientRef: "tenant-a", AccountID: "acct-1"}
+	dynKey := TokenKey{ServerURL: "https://api.example.com", AccountID: "acct-1"}
+	tokens.entries[refKey] = &TokenEntry{AccessToken: "ref-at", State: SessionActive}
+	tokens.entries[dynKey] = &TokenEntry{AccessToken: "dyn-at", State: SessionActive}
+	do := func(_ *http.Request) (*http.Response, error) { return jsonStatusResponse(http.StatusOK, "{}"), nil }
+
+	if err := revokeToken(context.Background(), tokens, do, newFakeServerCache(), newFakeClientStore(), "https://api.example.com", "tenant-a", "acct-1"); err != nil {
+		// No revocation endpoint advertised → server error surfaced, but local
+		// state must still transition. That is asserted below; tolerate the error.
+		_ = err
+	}
+	if tokens.entries[refKey].State != SessionRevoked {
+		t.Errorf("tenant-a token state = %q, want revoked", tokens.entries[refKey].State)
+	}
+	if tokens.entries[dynKey].State != SessionActive {
+		t.Errorf("dynamic token must be untouched, state = %q", tokens.entries[dynKey].State)
+	}
+
+	st, err := getSessionState(context.Background(), tokens, "https://api.example.com", "tenant-a", "acct-1")
+	if err != nil {
+		t.Fatalf("session state: %v", err)
+	}
+	if st != SessionRevoked {
+		t.Errorf("session state = %q, want revoked", st)
+	}
+
+	if err := deleteToken(context.Background(), tokens, "https://api.example.com", "tenant-a", "acct-1"); err != nil {
+		t.Fatalf("delete: %v", err)
+	}
+	if _, ok := tokens.entries[refKey]; ok {
+		t.Error("tenant-a token must be deleted")
+	}
+	if _, ok := tokens.entries[dynKey]; !ok {
+		t.Error("dynamic token must survive deletion of the tenant-a token")
+	}
+}
+
+// ListTokens is scoped to a single ClientRef: it returns only tokens for that
+// ref, not the dynamic slot or other refs on the same server.
+func TestListTokens_ByClientRef(t *testing.T) {
+	tokens := newFakeTokenStore()
+	tokens.entries[TokenKey{ServerURL: "https://api.example.com", AccountID: "a"}] = &TokenEntry{AccessToken: "dyn"}
+	tokens.entries[TokenKey{ServerURL: "https://api.example.com", ClientRef: "tenant-a", AccountID: "b"}] = &TokenEntry{AccessToken: "ta"}
+	tokens.entries[TokenKey{ServerURL: "https://api.example.com", ClientRef: "tenant-b", AccountID: "c"}] = &TokenEntry{AccessToken: "tb"}
+
+	list, err := listTokens(context.Background(), tokens, "https://api.example.com", "tenant-a")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(list) != 1 || list[0].AccessToken != "ta" {
+		t.Errorf("ListTokens(tenant-a) = %+v, want only the tenant-a token", list)
+	}
+	if m, ok := tokens.lastFilter.(bson.M); !ok || m["_id.clientRef"] != "tenant-a" {
+		t.Errorf("expected a clientRef filter, got %v", tokens.lastFilter)
 	}
 }


### PR DESCRIPTION
## Summary

Implements **AUTH-0011** (Commit 3 of the OAuth Multi-Client Support proposal). Threads the consumer-defined opaque `ClientRef` through the full token lifecycle and the Authorization Code + PKCE flow, so tokens are stored and retrieved per `(ServerURL, ClientRef, AccountID)`. After this change, tokens for the same `(server, account)` but different `ClientRef` values (e.g. the dynamic slot `""` vs a static `tenant-a` client) coexist independently.

Depends on AUTH-0009 (key/option structs) and AUTH-0010 (registration + static clients), both already merged.

## Changes

### `oauth/token.go`
- `tokenKeyFor(serverURL, clientRef, accountID)` now builds `TokenKey{ServerURL, ClientRef, AccountID}`.
- Package helpers `getToken` / `forceRefresh` / `revokeToken` / `deleteToken` / `getSessionState` / `listTokens` gained a `clientRef` parameter (inserted between `serverURL` and `accountID`).
- All six public methods take `clientRef`: `GetToken` / `RefreshToken` / `RevokeToken` / `DeleteToken` / `GetSessionState` (between `serverURL` and `accountID`) and `ListTokens` (after `serverURL`).
- `lockedRefresh` (no new param) now adds `ClientRef` to the `TokenRefreshLockKey`. The deeper helpers `refreshTokenExchange` / `revokeAtServer` already read `key.ClientRef` (AUTH-0010).
- `listTokens` filters on `_id.clientRef` (final dynamic-`""` filter scoping is deferred to AUTH-0012, per the task).

### `oauth/authorization.go`
- `AuthorizationURL` stores `merged.ClientRef` in the persisted `PendingAuthState`.
- `HandleCallback` recovers `ps.ClientRef` to build the correct `TokenKey` for the new token.
- Diagnostic identity strings now include `ClientRef` (via a small `(*TokenKey).id()` helper) so messages are unambiguous once multiple clients share a `(server, account)` pair.

## Tests

- Re-covered every existing token/auth call site with the dynamic `""` case.
- New scenarios: token isolation (`""` vs `tenant-a`), authorize→callback `ClientRef` round-trip, lock-key carries `ClientRef`, ClientRef-scoped revoke/delete/session-state, `ListTokens` by ref, and `tokenKeyFor`/`AuthorizationURL` `ClientRef` coverage.

## Verification

- `go build ./...` ✅
- `go test ./oauth/...` ✅ (full `go test ./...` passes)
- `go vet ./oauth/...`, `gofmt -l oauth/`, `golangci-lint run ./oauth/` — clean (0 issues)

## Out of scope (deferred to AUTH-0012)

- Propagating `ClientRef` into the **refresh reconciler** lock key (`oauth/reconciler.go`).
- **Finalizing the `ListTokens` filter** for the dynamic `""` case (absent-vs-empty `clientRef` semantics under `omitempty`).

Both are explicitly assigned to AUTH-0012 in the proposal's commit breakdown.

Refs: AUTH-0011

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Enhanced OAuth token management with per-client isolation, ensuring tokens are properly scoped to specific client applications throughout the authorization and callback flow.
  * Token persistence and retrieval now include client reference tracking for improved separation of client credentials.

* **Tests**
  * Added comprehensive test coverage for client reference functionality across OAuth lifecycle operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->