### PR TITLE
feat(oauth): propagate ClientRef in reconciler and scope ListTokens

### DIFF
--- a/docs/oauth-client-library.md
+++ b/docs/oauth-client-library.md
@@ -27,11 +27,13 @@ callback endpoint and the frontend redirect.
 | In Scope | Out of Scope |
 |----------|--------------|
 | Server discovery (RFC 9728 / 8414 / OIDC) | Hosting HTTP callback/initiate endpoints |
-| Dynamic client registration (RFC 7591), public clients | Confidential clients / secret rotation |
-| Authorization Code + PKCE (RFC 7636) | Multiple clients per server |
-| Token persist / refresh / revoke (RFC 7009) | Static client registration body (stub only) |
-| Field-level encryption at rest | Consumer's UI / redirect rendering |
-| Cross-replica locking + reconciler refresh | Provider-specific business logic |
+| Dynamic client registration (RFC 7591), public clients | Confidential-client secret rotation |
+| Static client registration (consumer-provided credentials) | Consumer's UI / redirect rendering |
+| Multiple clients per server via `ClientRef` (multi-tenant) | Provider-specific business logic |
+| Authorization Code + PKCE (RFC 7636) | |
+| Token persist / refresh / revoke (RFC 7009) | |
+| Field-level encryption at rest | |
+| Cross-replica locking + reconciler refresh | |
 
 ---
 
@@ -65,12 +67,17 @@ auth/
 
 ### 3.1 Database & Collections
 
-| Collection            | Key                       | Purpose                                            |
-|-----------------------|---------------------------|----------------------------------------------------|
-| `servers`             | `ServerURL` (string)      | Cached discovery metadata per remote server        |
-| `clients`             | `ServerURL` (string)      | Registered OAuth client per remote server          |
-| `tokens`              | `{ServerURL, AccountID}`  | OAuth tokens per (server × account) pair           |
-| `pending_auth_states` | `State` (string)          | Transient PKCE/CSRF state for in-flight flows      |
+| Collection            | Key                                 | Purpose                                            |
+|-----------------------|-------------------------------------|----------------------------------------------------|
+| `servers`             | `ServerURL` (string)                | Cached discovery metadata per remote server        |
+| `clients`             | `{ServerURL, ClientRef}`            | Registered OAuth client per (server × client-ref)  |
+| `tokens`              | `{ServerURL, ClientRef, AccountID}` | OAuth tokens per (server × client-ref × account)    |
+| `pending_auth_states` | `State` (string)                    | Transient PKCE/CSRF state for in-flight flows      |
+
+`ClientRef` is a consumer-defined opaque label that disambiguates multiple
+clients registered against the same server (see §3.5). Dynamic registrations use
+the empty `ClientRef` (`""`), which `omitempty` omits from the stored key — so
+single-client deployments and existing data are unaffected.
 
 These collections live in the `db.Store` the consumer supplies to
 `NewOAuthManager` — the consuming service owns the connection and chooses the
@@ -108,6 +115,7 @@ type ServerEntry struct {
 // --- clients ---
 type ClientKey struct {
     ServerURL string `bson:"serverUrl"`
+    ClientRef string `bson:"clientRef,omitempty"` // consumer label; "" = dynamic
 }
 
 type ClientEntry struct {
@@ -126,6 +134,7 @@ type ClientEntry struct {
 // --- tokens ---
 type TokenKey struct {
     ServerURL string `bson:"serverUrl"`
+    ClientRef string `bson:"clientRef,omitempty"` // consumer label; "" = dynamic
     AccountID string `bson:"accountId"`
 }
 
@@ -157,6 +166,7 @@ type PendingAuthStateKey struct {
 
 type PendingAuthState struct {
     ServerURL    string    `bson:"serverUrl"`
+    ClientRef    string    `bson:"clientRef,omitempty"` // recovered by HandleCallback to build the TokenKey
     AccountID    string    `bson:"accountId"`
     CodeVerifier string    `bson:"codeVerifier"` // encrypted at rest
     RedirectURI  string    `bson:"redirectUri"`
@@ -189,16 +199,60 @@ pattern, using `utils.IOEncryptor` from `go-core-stack/core/utils`.
 ```go
 type RegistrationLockKey struct {
     ServerURL string `bson:"serverUrl"`
+    ClientRef string `bson:"clientRef,omitempty"`
 }
 
 type TokenRefreshLockKey struct {
     ServerURL string `bson:"serverUrl"`
+    ClientRef string `bson:"clientRef,omitempty"`
     AccountID string `bson:"accountId"`
 }
 ```
 
 Lock table names: `auth-library-registration-locks`,
-`auth-library-token-refresh-locks`.
+`auth-library-token-refresh-locks`. Including `ClientRef` keeps registration and
+refresh of one client from serializing on another client for the same server (or
+the same `(server, account)` pair).
+
+### 3.5 Multi-Client Support (`ClientRef`)
+
+A single deployment can register **multiple OAuth clients against the same
+server** — e.g. one static/confidential client per tenant, each with its own
+credentials. They are disambiguated by `ClientRef`.
+
+- **`ClientRef` is not `ClientID`.** `ClientEntry.ClientID` is the
+  OAuth-protocol identifier issued by the authorization server. `ClientRef` is a
+  *consumer-side* opaque label (tenant slug, config name, integration id) with no
+  protocol meaning; it exists only to key storage and retrieval.
+- **Key model.** `(ServerURL, ClientRef)` is unique per client;
+  `(ServerURL, ClientRef, AccountID)` is unique per token. Every client- and
+  token-resolving key carries `ClientRef`.
+- **Dynamic vs static.** Dynamic registration uses `ClientRef == ""` (the
+  implicit single-client slot). Static registration requires a non-empty
+  `ClientRef`; `RegisterStaticClient` rejects `""` so a static client can never
+  collide with the dynamic slot.
+- **No migration.** `ClientRef` uses the `omitempty` BSON tag. Writes with `""`
+  omit the field entirely, so new dynamic documents are byte-for-byte compatible
+  with pre-multi-client data, and existing documents (which lack the field)
+  decode to `ClientRef: ""`. No index changes are needed — the `core/table`
+  layer builds indexes from the struct tags, including `omitempty` semantics.
+
+```go
+// Register a tenant's pre-provisioned client once.
+err := mgr.RegisterStaticClient(ctx, "https://auth.example.com", "tenant-acme", oauth.ClientEntry{
+    ClientID:     "acme-client-id",
+    ClientSecret: "acme-client-secret",
+    ClientType:   "confidential",
+    RedirectURIs: []string{"https://app.example.com/callback"},
+    Scopes:       []string{"openid", "profile"},
+})
+
+// Subsequent token operations reference the same ClientRef.
+tok, err := mgr.GetToken(ctx, "https://auth.example.com", "tenant-acme", "user-123")
+
+// Dynamic (single-client) callers pass "".
+tok, err = mgr.GetToken(ctx, "https://auth.example.com", "", "user-123")
+```
 
 ---
 
@@ -235,6 +289,7 @@ func (m *OAuthManager) GetCachedServer(ctx context.Context, serverURL string) (*
 ```go
 type RegisterClientOptions struct {
     ServerURL    string
+    ClientRef    string   // consumer label; "" for the dynamic single-client slot
     ClientName   string   // defaults to OAuthConfig.ClientName
     RedirectURIs []string // defaults to []string{OAuthConfig.RedirectURI}
     Scopes       []string // defaults to OAuthConfig.Scopes
@@ -243,9 +298,13 @@ type RegisterClientOptions struct {
 
 func (m *OAuthManager) RegisterDynamicClient(ctx context.Context, opts RegisterClientOptions) (*ClientEntry, error)
 func (m *OAuthManager) ReRegisterClient(ctx context.Context, opts RegisterClientOptions) (*ClientEntry, error)
-func (m *OAuthManager) GetClient(ctx context.Context, serverURL string) (*ClientEntry, error)
-func (m *OAuthManager) RegisterStaticClient(ctx context.Context, serverURL string, entry ClientEntry) error // TODO: errors.Unimplemented
+func (m *OAuthManager) GetClient(ctx context.Context, serverURL, clientRef string) (*ClientEntry, error)
+func (m *OAuthManager) RegisterStaticClient(ctx context.Context, serverURL, clientRef string, entry ClientEntry) error
 ```
+
+`RegisterStaticClient` upserts a consumer-provided client under a **non-empty**
+`ClientRef` (it rejects `""`), setting `RegistrationType = "static"`. `GetClient`
+takes the `clientRef` selecting which client to retrieve for the server.
 
 ### 4.4 Authorization (PKCE)
 
@@ -264,6 +323,7 @@ type AuthorizationParams struct {
 
 type AuthorizeOptions struct {
     ServerURL   string
+    ClientRef   string            // selects the client; "" for the dynamic slot
     AccountID   string            // consumer's opaque identifier — never sent to server
     RedirectURI string            // defaults to OAuthConfig.RedirectURI
     Scopes      []string          // defaults to OAuthConfig.Scopes
@@ -277,17 +337,27 @@ func (m *OAuthManager) HandleCallback(ctx context.Context, state string, code st
 `AuthorizationURL` returns **tokenized params**, not a full URL string — the
 consumer's frontend reconstructs the redirect URL. The `state` value in the
 callback URL is the session handle; there is no in-memory session object.
+`AuthorizationURL` records `opts.ClientRef` in the persisted `PendingAuthState`,
+and `HandleCallback` recovers it to store the resulting token under the correct
+`TokenKey` — so neither signature needs a `clientRef` parameter.
 
 ### 4.5 Token Management
 
 ```go
-func (m *OAuthManager) GetToken(ctx context.Context, serverURL, accountID string) (*TokenEntry, error)        // near-expiry auto-refresh
-func (m *OAuthManager) RefreshToken(ctx context.Context, serverURL, accountID string) (*TokenEntry, error)    // forced
-func (m *OAuthManager) RevokeToken(ctx context.Context, serverURL, accountID string) error                    // RFC 7009
-func (m *OAuthManager) DeleteToken(ctx context.Context, serverURL, accountID string) error
-func (m *OAuthManager) GetSessionState(ctx context.Context, serverURL, accountID string) (SessionState, error)
-func (m *OAuthManager) ListTokens(ctx context.Context, serverURL string) ([]*TokenEntry, error)
+func (m *OAuthManager) GetToken(ctx context.Context, serverURL, clientRef, accountID string) (*TokenEntry, error)        // near-expiry auto-refresh
+func (m *OAuthManager) RefreshToken(ctx context.Context, serverURL, clientRef, accountID string) (*TokenEntry, error)    // forced
+func (m *OAuthManager) RevokeToken(ctx context.Context, serverURL, clientRef, accountID string) error                    // RFC 7009
+func (m *OAuthManager) DeleteToken(ctx context.Context, serverURL, clientRef, accountID string) error
+func (m *OAuthManager) GetSessionState(ctx context.Context, serverURL, clientRef, accountID string) (SessionState, error)
+func (m *OAuthManager) ListTokens(ctx context.Context, serverURL, clientRef string) ([]*TokenEntry, error)
 ```
+
+Every token method takes `clientRef` (between `serverURL` and `accountID`;
+`ListTokens` after `serverURL`). Dynamic callers pass `""`. `ListTokens` is
+scoped to a **single** `ClientRef` — there is no wildcard/list-all mode; its
+primary use is invalidating a static client's tokens when that client is removed.
+The `""` case matches dynamic tokens via an absent-or-empty filter
+(`$in:["", nil]`), since dynamic documents omit the `clientRef` field entirely.
 
 ---
 
@@ -312,7 +382,7 @@ RegisterDynamicClient(opts)
   ├── merge opts with config defaults
   ├── clientTable has entry? → return (idempotent)
   └── else:
-      ├── acquire registration lock (key=serverURL)
+      ├── acquire registration lock (key={serverURL, clientRef})
       ├── double-check clientTable
       ├── DiscoverServer(serverURL)
       ├── POST {registrationEndpoint}  (RFC 7591, token_endpoint_auth_method:"none")
@@ -340,10 +410,10 @@ HandleCallback(state, code)
 
 ### 5.4 Token Refresh
 ```
-GetToken(serverURL, accountID)
+GetToken(serverURL, clientRef, accountID)
   ├── ExpiresAt > now + threshold → return as-is
   └── near expiry:
-      ├── acquire refresh lock; re-read token
+      ├── acquire refresh lock (key={serverURL, clientRef, accountID}); re-read token
       ├── POST {tokenEndpoint} grant_type=refresh_token
       │     success      → update, state=active
       │     transient    → state=failed, keep token
@@ -426,10 +496,12 @@ when a consumer requires them:
 
 | Item | Current Decision | Re-evaluate When |
 |------|------------------|------------------|
-| Confidential (private) clients | Only public clients supported | A consumer requires `token_endpoint_auth_method` other than `none` |
-| Static client registration | Interface defined; body returns `errors.Unimplemented` | A target server does not support RFC 7591 dynamic registration |
+| Confidential-client secret rotation | Static clients store provided credentials; no rotation flow | A consumer needs automated secret rotation |
 | Client expiry detection | Reactive — re-register on `invalid_client` → `revoked` | Servers begin issuing short-lived client registrations |
-| Multiple clients per server | One client per server (key = `ServerURL`) | A consumer needs distinct clients on the same server |
+| `ListTokens` wildcard / list-all mode | Scoped to a single `ClientRef`; no cross-ref listing | A consumer needs to enumerate every client's tokens for a server |
+
+> **Now supported (was deferred):** static client registration and multiple
+> clients per server — both delivered via the `ClientRef` key model (§3.5).
 
 ---
 

--- a/oauth/reconciler.go
+++ b/oauth/reconciler.go
@@ -154,8 +154,11 @@ func (r *tokenRefreshReconciler) Reconcile(k any) (*reconciler.Result, error) {
 		return &reconciler.Result{RequeueAfter: timeUntilRefresh(entry, now)}, nil
 	}
 
-	// near expiry — serialize refresh across instances with a distributed lock
-	lock, err := r.locks.TryAcquire(ctx, &TokenRefreshLockKey{ServerURL: key.ServerURL, AccountID: key.AccountID})
+	// near expiry — serialize refresh across instances with a distributed lock.
+	// The lock key carries ClientRef (sourced from the token key) so a static
+	// client's refresh does not serialize on the dynamic slot — or another
+	// client — for the same (server, account) pair.
+	lock, err := r.locks.TryAcquire(ctx, &TokenRefreshLockKey{ServerURL: key.ServerURL, ClientRef: key.ClientRef, AccountID: key.AccountID})
 	if err != nil {
 		// another instance is refreshing (or the lock is briefly contended);
 		// back off and retry rather than spinning
@@ -163,7 +166,7 @@ func (r *tokenRefreshReconciler) Reconcile(k any) (*reconciler.Result, error) {
 	}
 	defer func() {
 		if cerr := lock.Close(); cerr != nil {
-			log.Printf("oauth: failed to release token-refresh lock for %s/%s: %s", key.ServerURL, key.AccountID, cerr)
+			log.Printf("oauth: failed to release token-refresh lock for %s: %s", key.id(), cerr)
 		}
 	}()
 
@@ -196,14 +199,14 @@ func (r *tokenRefreshReconciler) Reconcile(k any) (*reconciler.Result, error) {
 			return nil, nil
 		case errors.Is(err, errRefreshNotImplemented):
 			// AUTH-0007 will wire the real exchange; defer to avoid a hot loop
-			log.Printf("oauth: token refresh not yet implemented (AUTH-0007); deferring %s/%s", key.ServerURL, key.AccountID)
+			log.Printf("oauth: token refresh not yet implemented (AUTH-0007); deferring %s", key.id())
 			return &reconciler.Result{RequeueAfter: RefreshThreshold}, nil
 		default:
 			// transient — requeue with a backoff rather than returning a bare
 			// error (which the pipeline would re-enqueue immediately, hot-looping
 			// the token endpoint during a sustained outage)
-			log.Printf("oauth: transient token-refresh failure for %s/%s, retrying in %s: %s",
-				key.ServerURL, key.AccountID, transientRefreshBackoff, err)
+			log.Printf("oauth: transient token-refresh failure for %s, retrying in %s: %s",
+				key.id(), transientRefreshBackoff, err)
 			return &reconciler.Result{RequeueAfter: transientRefreshBackoff}, nil
 		}
 	}

--- a/oauth/reconciler_test.go
+++ b/oauth/reconciler_test.go
@@ -212,6 +212,45 @@ func TestTokenReconciler_NearExpiryRefreshSuccess(t *testing.T) {
 	if fl.lock == nil || !fl.lock.closed {
 		t.Errorf("refresh lock should be acquired and released")
 	}
+	// A dynamic token (no ClientRef) must lock under the dynamic slot.
+	if fl.lastKey == nil || fl.lastKey.ClientRef != "" {
+		t.Errorf("dynamic token lock key must carry empty ClientRef, got %+v", fl.lastKey)
+	}
+}
+
+// A token stored under a non-empty ClientRef must refresh against that client:
+// the reconciler sources ClientRef from the token key into the refresh lock key,
+// and the refresh func receives the ClientRef-carrying key (which threads into
+// findClient, so a static client refreshes against its own registration and not
+// the dynamic slot).
+func TestTokenReconciler_RefreshThreadsClientRef(t *testing.T) {
+	key := &TokenKey{ServerURL: "https://example.com", ClientRef: "tenant-a", AccountID: "user-1"}
+	ft := newFakeTokenTable()
+	ft.entries[*key] = &TokenEntry{State: SessionActive, ExpiresAt: time.Now().Add(time.Minute).Unix()}
+	fl := &fakeLocker{}
+
+	var gotKey *TokenKey
+	r := &tokenRefreshReconciler{
+		tokens: ft,
+		locks:  fl,
+		refresh: func(_ context.Context, k *TokenKey, _ *TokenEntry) (*TokenEntry, error) {
+			gotKey = k
+			return &TokenEntry{State: SessionActive, AccessToken: "new", ExpiresAt: time.Now().Add(time.Hour).Unix()}, nil
+		},
+	}
+
+	if _, err := r.Reconcile(key); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if fl.lastKey == nil || fl.lastKey.ClientRef != "tenant-a" {
+		t.Errorf("refresh lock key ClientRef = %+v, want tenant-a", fl.lastKey)
+	}
+	if fl.lastKey.ServerURL != "https://example.com" || fl.lastKey.AccountID != "user-1" {
+		t.Errorf("lock key = %+v, want server/account preserved", fl.lastKey)
+	}
+	if gotKey == nil || gotKey.ClientRef != "tenant-a" {
+		t.Errorf("refresh received key %+v, want ClientRef tenant-a (threads into findClient)", gotKey)
+	}
 }
 
 func TestTokenReconciler_PermanentFailureRevokes(t *testing.T) {

--- a/oauth/token.go
+++ b/oauth/token.go
@@ -425,10 +425,23 @@ func getSessionState(ctx context.Context, tokens tokenStore, serverURL, clientRe
 // listTokens implements ListTokens. The listing is scoped to a single clientRef
 // on the token key (_id): an empty serverURL spans every server for that
 // clientRef, a non-empty one also filters by the normalized server URL. A zero
-// limit means no limit. (Final filter scoping for the dynamic "" clientRef is
-// finalized in AUTH-0012.)
+// limit means no limit.
+//
+// The clientRef filter is asymmetric. A non-empty clientRef is a plain equality.
+// The dynamic case (clientRef == "") must NOT use a naive {"_id.clientRef": ""}:
+// dynamic token documents omit clientRef entirely (the omitempty BSON tag), and
+// in MongoDB an equality against "" does not match a document that lacks the
+// field. Match absent-or-empty explicitly with $in:["",nil] instead. (Point
+// lookups — GetToken/DeleteToken/etc. — marshal the full TokenKey _id with
+// omitempty, so they already match correctly and need no special-casing; this
+// asymmetry is unique to ListTokens' partial filter.)
 func listTokens(ctx context.Context, tokens tokenStore, serverURL string, clientRef string) ([]*TokenEntry, error) {
-	filter := bson.M{"_id.clientRef": clientRef}
+	filter := bson.M{}
+	if clientRef == "" {
+		filter["_id.clientRef"] = bson.M{"$in": bson.A{"", nil}}
+	} else {
+		filter["_id.clientRef"] = clientRef
+	}
 	if normalized := normalizeServerURL(serverURL); normalized != "" {
 		filter["_id.serverUrl"] = normalized
 	}

--- a/oauth/token_test.go
+++ b/oauth/token_test.go
@@ -75,13 +75,29 @@ func (f *fakeTokenStore) Locate(ctx context.Context, key *TokenKey, entry *Token
 func (f *fakeTokenStore) FindMany(_ context.Context, filter any, _, _ int32) ([]*TokenEntry, error) {
 	f.lastFilter = filter
 	want, byServer := "", false
-	wantRef, byRef := "", false
+	matchRef := func(string) bool { return true }
 	if m, ok := filter.(bson.M); ok {
 		if s, ok := m["_id.serverUrl"].(string); ok {
 			want, byServer = s, true
 		}
-		if s, ok := m["_id.clientRef"].(string); ok {
-			wantRef, byRef = s, true
+		switch v := m["_id.clientRef"].(type) {
+		case string:
+			// non-empty clientRef → plain equality
+			matchRef = func(ref string) bool { return ref == v }
+		case bson.M:
+			// dynamic "" → $in:["",nil] matching absent-or-empty clientRef
+			in, _ := v["$in"].(bson.A)
+			matchRef = func(ref string) bool {
+				for _, w := range in {
+					if w == nil && ref == "" {
+						return true
+					}
+					if s, ok := w.(string); ok && s == ref {
+						return true
+					}
+				}
+				return false
+			}
 		}
 	}
 	var out []*TokenEntry
@@ -89,7 +105,7 @@ func (f *fakeTokenStore) FindMany(_ context.Context, filter any, _, _ int32) ([]
 		if byServer && k.ServerURL != want {
 			continue
 		}
-		if byRef && k.ClientRef != wantRef {
+		if !matchRef(k.ClientRef) {
 			continue
 		}
 		cp := *e
@@ -815,5 +831,37 @@ func TestListTokens_ByClientRef(t *testing.T) {
 	}
 	if m, ok := tokens.lastFilter.(bson.M); !ok || m["_id.clientRef"] != "tenant-a" {
 		t.Errorf("expected a clientRef filter, got %v", tokens.lastFilter)
+	}
+}
+
+// ListTokens("") lists only dynamic tokens. Dynamic documents omit clientRef
+// entirely (omitempty), so the filter must match absent-or-empty via
+// $in:["",nil] — a naive {"_id.clientRef": ""} would miss them in MongoDB.
+func TestListTokens_DynamicMatchesAbsentOrEmpty(t *testing.T) {
+	tokens := newFakeTokenStore()
+	tokens.entries[TokenKey{ServerURL: "https://api.example.com", AccountID: "a"}] = &TokenEntry{AccessToken: "dyn"}
+	tokens.entries[TokenKey{ServerURL: "https://api.example.com", ClientRef: "tenant-a", AccountID: "b"}] = &TokenEntry{AccessToken: "ta"}
+	tokens.entries[TokenKey{ServerURL: "https://api.example.com", ClientRef: "tenant-b", AccountID: "c"}] = &TokenEntry{AccessToken: "tb"}
+
+	list, err := listTokens(context.Background(), tokens, "https://api.example.com", "")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(list) != 1 || list[0].AccessToken != "dyn" {
+		t.Errorf("ListTokens(\"\") = %+v, want only the dynamic token", list)
+	}
+	m, ok := tokens.lastFilter.(bson.M)
+	if !ok {
+		t.Fatalf("expected a bson.M filter, got %T", tokens.lastFilter)
+	}
+	// The dynamic clientRef filter must be an absent-or-empty match, not a naive
+	// equality (which would skip documents that omit the field entirely).
+	sub, ok := m["_id.clientRef"].(bson.M)
+	if !ok {
+		t.Fatalf("dynamic clientRef filter must be a sub-document ($in), got %T: %v", m["_id.clientRef"], m["_id.clientRef"])
+	}
+	in, ok := sub["$in"].(bson.A)
+	if !ok || len(in) != 2 {
+		t.Errorf("expected $in:[\"\",nil], got %v", sub)
 	}
 }


### PR DESCRIPTION
## Summary

Implements **AUTH-0012** (Commit 4 of the OAuth Multi-Client Support proposal). Propagates the consumer-defined opaque `ClientRef` through the token-refresh reconciler, finalizes `ListTokens` filtering to scope by `ClientRef`, and updates the design documentation to reflect multi-client support.

Depends on AUTH-0011 (token lifecycle + auth flow `ClientRef` threading), already merged.

## Changes

### `oauth/reconciler.go`
- The token-refresh reconciler now builds `TokenRefreshLockKey` with `ClientRef` sourced from `TokenKey.ClientRef` (previously `{ServerURL, AccountID}` only), so a static client's refresh no longer serializes against the dynamic slot — or another client — for the same `(server, account)` pair.
- `ClientRef` threads into the client lookup via the refresh func (`m.refreshToken` → `refreshTokenExchange` → `findClient(..., key.ClientRef)`), so a static client refreshes against its own registration.
- Diagnostic log lines now use `(*TokenKey).id()` so the client dimension is unambiguous.

### `oauth/token.go` (`listTokens`)
- Finalized the `ListTokens` filter. A non-empty `clientRef` is a plain equality. The dynamic case (`clientRef == ""`) uses `$in:["", nil]` to match absent-or-empty — a naive `{"_id.clientRef": ""}` would miss documents that omit the field entirely under `omitempty`.
- Scoped to a **single** `ClientRef`; no wildcard / list-all mode (resolved decision §2). Primary use case is token invalidation when a static client is removed.

### `docs/oauth-client-library.md`
- Documented multi-client support: the `ClientRef` vs `ClientID` concept, the `(ServerURL, ClientRef)` / `(ServerURL, ClientRef, AccountID)` key model, `RegisterStaticClient` usage, updated key/lock/token-method signatures, and the no-migration note. Moved static clients & multiple-clients-per-server out of "deferred".

## Tests

- **Reconciler:** `TestTokenReconciler_RefreshThreadsClientRef` verifies the lock key and the refresh func both carry the static `ClientRef`; the dynamic case asserts an empty ref.
- **ListTokens:** `TestListTokens_DynamicMatchesAbsentOrEmpty` verifies `""` returns only dynamic tokens and emits the `$in:["",nil]` filter; existing `TestListTokens_ByClientRef` covers a specific ref. The fake `FindMany` was updated to honor the `$in` form.

## Verification

- `go build ./...` ✅
- `go test ./...` ✅
- `go vet ./oauth/...`, `gofmt -l`, `golangci-lint run ./oauth/...` — clean (0 issues)

## Notes / out of scope

- The reconciler→`findClient` `ClientRef` leg is covered structurally (the full `TokenKey` is threaded) and by `token.go`'s refresh unit tests, rather than by a single end-to-end reconciler test (the reconciler tests use a fake refresh func, the established pattern in this package).

Refs: AUTH-0012