### PR TITLE
refactor(oauth): migrate stored state fields to int-based enums

### DIFF
--- a/oauth/encryption_test.go
+++ b/oauth/encryption_test.go
@@ -85,8 +85,8 @@ func TestClientEntryEncryptionRoundTrip(t *testing.T) {
 		ClientID:                "client-123",
 		ClientSecret:            "super-secret-client-secret",
 		RegistrationAccessToken: "super-secret-registration-token",
-		ClientType:              "public",
-		RegistrationType:        "dynamic",
+		ClientType:              ClientTypeConfidential,
+		RegistrationType:        RegistrationTypeStatic,
 	}
 
 	data, err := bson.Marshal(orig)
@@ -117,6 +117,13 @@ func TestClientEntryEncryptionRoundTrip(t *testing.T) {
 	}
 	if got.ClientID != orig.ClientID {
 		t.Errorf("clientId: got %q, want %q", got.ClientID, orig.ClientID)
+	}
+	// Int-enum fields survive the round-trip unchanged.
+	if got.ClientType != orig.ClientType {
+		t.Errorf("clientType: got %d, want %d", got.ClientType, orig.ClientType)
+	}
+	if got.RegistrationType != orig.RegistrationType {
+		t.Errorf("registrationType: got %d, want %d", got.RegistrationType, orig.RegistrationType)
 	}
 }
 

--- a/oauth/registration.go
+++ b/oauth/registration.go
@@ -16,12 +16,8 @@ import (
 	coresync "github.com/go-core-stack/core/sync"
 )
 
-// ClientType / RegistrationType values persisted on ClientEntry.
 const (
-	clientTypePublic        = "public"
-	registrationTypeDynamic = "dynamic"
-	registrationTypeStatic  = "static"
-	responseTypeCode        = "code"
+	responseTypeCode = "code"
 )
 
 // clientStore is the subset of the client table that registration needs. The
@@ -239,8 +235,8 @@ func performRegistration(ctx context.Context, do httpDoFunc, clients clientStore
 		RegistrationAccessToken: resp.RegistrationAccessToken,
 		RedirectURIs:            preferStrings(resp.RedirectURIs, merged.RedirectURIs),
 		Scopes:                  preferStrings(strings.Fields(resp.Scope), merged.Scopes),
-		ClientType:              clientTypePublic,
-		RegistrationType:        registrationTypeDynamic,
+		ClientType:              ClientTypePublic,
+		RegistrationType:        RegistrationTypeDynamic,
 		RegisteredAt:            time.Now().Unix(),
 	}
 
@@ -268,7 +264,7 @@ func registerStaticClient(ctx context.Context, clients clientStore, serverURL, c
 		return errors.Wrap(errors.InvalidArgument, "oauth: serverURL must not be empty")
 	}
 
-	entry.RegistrationType = registrationTypeStatic
+	entry.RegistrationType = RegistrationTypeStatic
 	entry.RegisteredAt = time.Now().Unix()
 
 	// Upsert so a static client can be re-provisioned (e.g. rotated secret)

--- a/oauth/registration_test.go
+++ b/oauth/registration_test.go
@@ -192,11 +192,11 @@ func TestRegisterDynamicClient_HappyPath(t *testing.T) {
 	if entry.RegistrationAccessToken != "rat-123" {
 		t.Errorf("registration access token = %q", entry.RegistrationAccessToken)
 	}
-	if entry.ClientType != clientTypePublic {
-		t.Errorf("client type = %q, want %q", entry.ClientType, clientTypePublic)
+	if entry.ClientType != ClientTypePublic {
+		t.Errorf("client type = %d, want %d", entry.ClientType, ClientTypePublic)
 	}
-	if entry.RegistrationType != registrationTypeDynamic {
-		t.Errorf("registration type = %q, want %q", entry.RegistrationType, registrationTypeDynamic)
+	if entry.RegistrationType != RegistrationTypeDynamic {
+		t.Errorf("registration type = %d, want %d", entry.RegistrationType, RegistrationTypeDynamic)
 	}
 	if entry.RegisteredAt == 0 {
 		t.Error("RegisteredAt should be set")
@@ -607,7 +607,7 @@ func TestRegisterStaticClient_SetsMetadataAndUpserts(t *testing.T) {
 
 	// trailing slash exercises normalization on the write path
 	err := registerStaticClient(context.Background(), clients, "https://api.example.com/", "tenant-a",
-		ClientEntry{ClientID: "static-id", ClientSecret: "shh", ClientType: "confidential"})
+		ClientEntry{ClientID: "static-id", ClientSecret: "shh", ClientType: ClientTypeConfidential})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -616,14 +616,14 @@ func TestRegisterStaticClient_SetsMetadataAndUpserts(t *testing.T) {
 	if stored == nil {
 		t.Fatalf("client not persisted under normalized (server, clientRef) key; keys=%v", clients.entries)
 	}
-	if stored.RegistrationType != registrationTypeStatic {
-		t.Errorf("registration type = %q, want %q", stored.RegistrationType, registrationTypeStatic)
+	if stored.RegistrationType != RegistrationTypeStatic {
+		t.Errorf("registration type = %d, want %d", stored.RegistrationType, RegistrationTypeStatic)
 	}
 	if stored.RegisteredAt == 0 {
 		t.Error("RegisteredAt should be set")
 	}
-	if stored.ClientType != "confidential" {
-		t.Errorf("ClientType = %q, want consumer-supplied %q", stored.ClientType, "confidential")
+	if stored.ClientType != ClientTypeConfidential {
+		t.Errorf("ClientType = %d, want consumer-supplied %d", stored.ClientType, ClientTypeConfidential)
 	}
 	if stored.ClientID != "static-id" || stored.ClientSecret != "shh" {
 		t.Errorf("consumer-supplied credentials not preserved: %+v", stored)
@@ -631,7 +631,7 @@ func TestRegisterStaticClient_SetsMetadataAndUpserts(t *testing.T) {
 
 	// Locate is an upsert: re-registering the same ref must not error.
 	if err := registerStaticClient(context.Background(), clients, "https://api.example.com", "tenant-a",
-		ClientEntry{ClientID: "rotated", ClientSecret: "shh2", ClientType: "confidential"}); err != nil {
+		ClientEntry{ClientID: "rotated", ClientSecret: "shh2", ClientType: ClientTypeConfidential}); err != nil {
 		t.Fatalf("re-provisioning a static client must succeed: %v", err)
 	}
 	if got := clients.entries[ckey("https://api.example.com", "tenant-a")]; got == nil || got.ClientID != "rotated" {
@@ -646,11 +646,11 @@ func TestRegisterStaticClient_TwoTenantsSameServer(t *testing.T) {
 	const server = "https://api.example.com"
 
 	if err := registerStaticClient(context.Background(), clients, server, "tenant-a",
-		ClientEntry{ClientID: "id-a", ClientType: "confidential"}); err != nil {
+		ClientEntry{ClientID: "id-a", ClientType: ClientTypeConfidential}); err != nil {
 		t.Fatalf("tenant-a registration failed: %v", err)
 	}
 	if err := registerStaticClient(context.Background(), clients, server, "tenant-b",
-		ClientEntry{ClientID: "id-b", ClientType: "confidential"}); err != nil {
+		ClientEntry{ClientID: "id-b", ClientType: ClientTypeConfidential}); err != nil {
 		t.Fatalf("tenant-b registration failed: %v", err)
 	}
 
@@ -684,7 +684,7 @@ func TestRegisterStaticClient_CoexistsWithDynamic(t *testing.T) {
 
 	// Static client for the same server under a distinct clientRef.
 	if err := registerStaticClient(context.Background(), clients, server, "tenant-a",
-		ClientEntry{ClientID: "static-id", ClientType: "confidential"}); err != nil {
+		ClientEntry{ClientID: "static-id", ClientType: ClientTypeConfidential}); err != nil {
 		t.Fatalf("static registration failed: %v", err)
 	}
 
@@ -692,15 +692,15 @@ func TestRegisterStaticClient_CoexistsWithDynamic(t *testing.T) {
 	if err != nil || gotDyn == nil || gotDyn.ClientID != dyn.ClientID {
 		t.Errorf("dynamic client clobbered: got %v err=%v, want %q", gotDyn, err, dyn.ClientID)
 	}
-	if gotDyn.RegistrationType != registrationTypeDynamic {
-		t.Errorf("dynamic slot type = %q, want %q", gotDyn.RegistrationType, registrationTypeDynamic)
+	if gotDyn.RegistrationType != RegistrationTypeDynamic {
+		t.Errorf("dynamic slot type = %d, want %d", gotDyn.RegistrationType, RegistrationTypeDynamic)
 	}
 	gotStatic, err := getClient(context.Background(), clients, server, "tenant-a")
 	if err != nil || gotStatic == nil || gotStatic.ClientID != "static-id" {
 		t.Errorf("static client lookup = %v err=%v, want static-id", gotStatic, err)
 	}
-	if gotStatic.RegistrationType != registrationTypeStatic {
-		t.Errorf("static slot type = %q, want %q", gotStatic.RegistrationType, registrationTypeStatic)
+	if gotStatic.RegistrationType != RegistrationTypeStatic {
+		t.Errorf("static slot type = %d, want %d", gotStatic.RegistrationType, RegistrationTypeStatic)
 	}
 }
 

--- a/oauth/token.go
+++ b/oauth/token.go
@@ -205,7 +205,7 @@ func lockedRefresh(ctx context.Context, tokens tokenStore, locks refreshLockerAP
 		}
 		entry.ErrorReason = err.Error()
 		if uerr := tokens.Update(ctx, key, entry); uerr != nil {
-			log.Printf("oauth: failed to persist %s state for %s after refresh failure: %s",
+			log.Printf("oauth: failed to persist state %d for %s after refresh failure: %s",
 				entry.State, key.id(), uerr)
 		}
 		return nil, err
@@ -410,14 +410,15 @@ func deleteToken(ctx context.Context, tokens tokenStore, serverURL, clientRef, a
 func getSessionState(ctx context.Context, tokens tokenStore, serverURL, clientRef, accountID string) (SessionState, error) {
 	key, err := tokenKeyFor(serverURL, clientRef, accountID)
 	if err != nil {
-		return "", err
+		// State is meaningless on the error path; callers must check err first.
+		return 0, err
 	}
 	entry, err := tokens.Find(ctx, key)
 	if err != nil {
 		if errors.IsNotFound(err) {
-			return "", errors.Wrapf(errors.NotFound, "oauth: no token for %s", key.id())
+			return 0, errors.Wrapf(errors.NotFound, "oauth: no token for %s", key.id())
 		}
-		return "", err
+		return 0, err
 	}
 	return entry.State, nil
 }

--- a/oauth/types.go
+++ b/oauth/types.go
@@ -13,19 +13,61 @@ import (
 	"github.com/go-core-stack/core/utils"
 )
 
-// SessionState captures the lifecycle state of a stored token.
-type SessionState string
+// SessionState captures the lifecycle state of a stored token. It is an
+// int-based enum: storage-efficient and robust to compare. SessionActive is
+// the zero value and the correct default for a freshly issued token.
+type SessionState int
 
 const (
 	// SessionActive indicates the token is valid and usable.
-	SessionActive SessionState = "active"
+	SessionActive SessionState = iota // 0
 	// SessionExpired indicates the token expired and a refresh is needed.
-	SessionExpired SessionState = "expired"
+	SessionExpired // 1
 	// SessionRevoked indicates the token was explicitly revoked or refresh
 	// failed permanently; re-authorization is required.
-	SessionRevoked SessionState = "revoked"
+	SessionRevoked // 2
 	// SessionFailed indicates a transient refresh failure that is retryable.
-	SessionFailed SessionState = "failed"
+	SessionFailed // 3
+)
+
+// ClientType distinguishes a public OAuth client (no secret) from a
+// confidential one (authenticates with a secret). ClientTypePublic is the zero
+// value.
+type ClientType int
+
+const (
+	// ClientTypePublic is a public client with no client secret.
+	ClientTypePublic ClientType = iota // 0
+	// ClientTypeConfidential is a confidential client that authenticates with
+	// a client secret.
+	ClientTypeConfidential // 1
+)
+
+// RegistrationType records how a client was provisioned: via RFC 7591 dynamic
+// registration or pre-provisioned statically by the consumer.
+// RegistrationTypeDynamic is the zero value.
+type RegistrationType int
+
+const (
+	// RegistrationTypeDynamic is a client created via RFC 7591 dynamic
+	// registration.
+	RegistrationTypeDynamic RegistrationType = iota // 0
+	// RegistrationTypeStatic is a consumer-pre-provisioned client.
+	RegistrationTypeStatic // 1
+)
+
+// RefreshPolicy records whether a stored token may be silently refreshed.
+// RefreshPolicyRefreshable is the zero value. The TokenEntry.RefreshPolicy
+// field and the set/check logic that consumes it land in AUTH-0017; this type
+// is only defined here.
+type RefreshPolicy int
+
+const (
+	// RefreshPolicyRefreshable allows the token to be proactively refreshed.
+	RefreshPolicyRefreshable RefreshPolicy = iota // 0
+	// RefreshPolicyNoRefresh marks a token that must not be auto-refreshed
+	// (e.g. an offline token that should not be revoked on near-expiry).
+	RefreshPolicyNoRefresh // 1
 )
 
 // --- servers ---
@@ -69,16 +111,16 @@ type ClientKey struct {
 // fields (ClientSecret, RegistrationAccessToken) are encrypted at rest via the
 // custom BSON marshalers in encryption.go.
 type ClientEntry struct {
-	ClientID                string   `bson:"clientId"`
-	ClientSecret            string   `bson:"clientSecret,omitempty"` // encrypted at rest
-	ClientSecretExpiresAt   int64    `bson:"clientSecretExpiresAt,omitempty"`
-	RegistrationURI         string   `bson:"registrationClientUri,omitempty"`   // RFC 7592
-	RegistrationAccessToken string   `bson:"registrationAccessToken,omitempty"` // encrypted at rest
-	RedirectURIs            []string `bson:"redirectUris,omitempty"`
-	Scopes                  []string `bson:"scopes,omitempty"`
-	ClientType              string   `bson:"clientType"`       // "public" | "confidential"
-	RegistrationType        string   `bson:"registrationType"` // "dynamic" | "static"
-	RegisteredAt            int64    `bson:"registeredAt,omitempty"`
+	ClientID                string           `bson:"clientId"`
+	ClientSecret            string           `bson:"clientSecret,omitempty"` // encrypted at rest
+	ClientSecretExpiresAt   int64            `bson:"clientSecretExpiresAt,omitempty"`
+	RegistrationURI         string           `bson:"registrationClientUri,omitempty"`   // RFC 7592
+	RegistrationAccessToken string           `bson:"registrationAccessToken,omitempty"` // encrypted at rest
+	RedirectURIs            []string         `bson:"redirectUris,omitempty"`
+	Scopes                  []string         `bson:"scopes,omitempty"`
+	ClientType              ClientType       `bson:"clientType"`
+	RegistrationType        RegistrationType `bson:"registrationType"`
+	RegisteredAt            int64            `bson:"registeredAt,omitempty"`
 }
 
 // --- tokens ---


### PR DESCRIPTION
## Summary

Migrates the persisted OAuth state fields from `string` to `int`-based enums (Commit 1 of the OAuth Library Enhancements proposal, `AUTH-0013`). String comparisons are fragile and storage-inefficient; int enums make the persisted state explicit and cheap to compare.

- `SessionState`, `ClientType`, `RegistrationType` become `int` enums with `iota` constants.
- Adds the `RefreshPolicy` int enum type (its `TokenEntry` field and logic land in AUTH-0017; only the type is defined here).
- `ClientEntry.ClientType`/`RegistrationType` and `TokenEntry.State` now use the typed int enums; BSON tags unchanged.
- Removes the string consts in `registration.go`; all use sites use the typed constants.
- Re-seeds test fixtures and strengthens the `ClientEntry` BSON round-trip to assert the int fields survive encode/decode.

No data migration and no backward-compat shim — this is a pre-production library with no deployed consumers or persisted production data. The zero values (`SessionActive`, `ClientTypePublic`, `RegistrationTypeDynamic`, `RefreshPolicyRefreshable`) are the correct defaults; no code path relied on the empty string as a sentinel distinct from the first enum value.

## Testing

- `go build ./...`
- `go vet ./oauth/...`
- `go test -race ./oauth/...`
- `golangci-lint run ./oauth/...` (0 issues)

Refs: AUTH-0013

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced OAuth token and client state management with improved type safety and consistency across the authentication system.

* **Tests**
  * Updated test assertions to validate OAuth client metadata with stronger type guarantees.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->