### PR TITLE
feat(oauth): add DeleteClient API with cascading token deletion

### DIFF
--- a/oauth/registration.go
+++ b/oauth/registration.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/go-core-stack/core/errors"
 	coresync "github.com/go-core-stack/core/sync"
+	"go.mongodb.org/mongo-driver/v2/bson"
 )
 
 const (
@@ -97,6 +98,18 @@ func (m *OAuthManager) GetClient(ctx context.Context, serverURL string, clientRe
 // be non-empty — "" is reserved exclusively for the dynamic client slot.
 func (m *OAuthManager) RegisterStaticClient(ctx context.Context, serverURL string, clientRef string, entry ClientEntry) error {
 	return registerStaticClient(ctx, m.clientTable, serverURL, clientRef, entry)
+}
+
+// DeleteClient removes a static client registration and cascade-deletes every
+// token issued for that (serverURL, clientRef) pair. It is the offboarding
+// counterpart to RegisterStaticClient: tokens are deleted first so a partial
+// failure never leaves orphaned tokens pointing at a deleted client. The cascade
+// and the record delete run under the per-(server, clientRef) registration lock
+// so they are atomic against a concurrent (re-)registration of the same client.
+// clientRef must be non-empty — the dynamic client slot ("") cannot be deleted
+// via this API. A missing client record is tolerated (idempotent).
+func (m *OAuthManager) DeleteClient(ctx context.Context, serverURL, clientRef string) error {
+	return deleteClient(ctx, m.clientTable, m.tokenTable, m.registrationLocks, serverURL, clientRef)
 }
 
 // registerDynamicClient implements RegisterDynamicClient against the
@@ -283,6 +296,67 @@ func registerStaticClient(ctx context.Context, clients clientStore, serverURL, c
 	if err := clients.Locate(ctx, &ClientKey{ServerURL: normalized, ClientRef: clientRef}, &entry); err != nil {
 		return errors.Wrapf(errors.GetErrCode(err),
 			"oauth: failed to persist static client for %s (clientRef %q): %s", normalized, clientRef, err)
+	}
+	return nil
+}
+
+// deleteClient implements DeleteClient against the clientStore / tokenDeleter /
+// registrationLocker interfaces so it is unit-testable with fakes. It
+// cascade-deletes the client's tokens before removing the client record:
+// ordering it this way means a partial failure (tokens deleted, client delete
+// fails) never leaves orphaned tokens pointing at a deleted client. Restricted
+// to static clients (clientRef != ""): the dynamic slot ("") cannot be deleted
+// here. A NotFound on the client delete is tolerated (idempotent) — the token
+// cascade may still have done useful work.
+//
+// The cascade and the record delete are performed under the per-(server,
+// clientRef) registration lock, mirroring reRegisterClient's discipline, so a
+// concurrent RegisterStaticClient / ReRegisterClient for the same client cannot
+// interleave with the delete (e.g. re-provision a client between the token
+// cascade and the record delete, leaving the freshly registered client
+// deleted). As in the re-register path, lock contention surfaces a retryable
+// error rather than racing — input validation runs first so an invalid request
+// never takes the lock.
+func deleteClient(ctx context.Context, clients clientStore, tokens tokenDeleter, locks registrationLocker, serverURL, clientRef string) error {
+	normalized := normalizeServerURL(serverURL)
+	if normalized == "" {
+		return errors.Wrap(errors.InvalidArgument, "oauth: serverURL must not be empty")
+	}
+	if strings.TrimSpace(clientRef) == "" {
+		return errors.Wrap(errors.InvalidArgument,
+			"oauth: clientRef must not be empty for client deletion")
+	}
+
+	// Serialize against (re-)registration of the same (server, clientRef). The
+	// lock is keyed identically to the registration paths, so a delete and a
+	// concurrent register cannot run at once. TryAcquire is non-blocking; on
+	// contention surface a retryable error rather than deleting under a peer's
+	// in-flight registration.
+	lock, err := locks.TryAcquire(ctx, &RegistrationLockKey{ServerURL: normalized, ClientRef: clientRef})
+	if err != nil {
+		return errors.Wrapf(errors.GetErrCode(err),
+			"oauth: registration in progress for %s (clientRef %q); retry deletion: %s", normalized, clientRef, err)
+	}
+	defer func() { _ = lock.Close() }()
+
+	// Cascade: delete all tokens for this (serverURL, clientRef). clientRef is a
+	// non-empty static value here, so plain equality is correct — this avoids the
+	// absent-or-empty subtlety that only affects the dynamic "" case in
+	// ListTokens. The deleted count is intentionally ignored.
+	filter := bson.M{
+		"_id.serverUrl": normalized,
+		"_id.clientRef": clientRef,
+	}
+	if _, err := tokens.DeleteByFilter(ctx, filter); err != nil {
+		return errors.Wrapf(errors.GetErrCode(err),
+			"oauth: failed to delete tokens for client %s/%s: %s", normalized, clientRef, err)
+	}
+
+	// Delete the client record; tolerate its absence so the operation is
+	// idempotent.
+	if err := clients.DeleteKey(ctx, &ClientKey{ServerURL: normalized, ClientRef: clientRef}); err != nil && !errors.IsNotFound(err) {
+		return errors.Wrapf(errors.GetErrCode(err),
+			"oauth: failed to delete client %s/%s: %s", normalized, clientRef, err)
 	}
 	return nil
 }

--- a/oauth/registration_test.go
+++ b/oauth/registration_test.go
@@ -773,6 +773,211 @@ func TestRegisterStaticClient_CoexistsWithDynamic(t *testing.T) {
 	}
 }
 
+// --- DeleteClient (cascade) ---
+
+// DeleteClient removes the client record and cascade-deletes every token issued
+// for that (server, clientRef).
+func TestDeleteClient_CascadeDeletesTokensAndClient(t *testing.T) {
+	const server = "https://api.example.com"
+	clients := newFakeClientStore()
+	if err := registerStaticClient(context.Background(), clients, server, "tenant-a",
+		ClientEntry{ClientID: "id-a", ClientSecret: "shh"}); err != nil {
+		t.Fatalf("setup: static registration failed: %v", err)
+	}
+	tokens := newFakeTokenStore()
+	for _, acct := range []string{"acct-1", "acct-2", "acct-3"} {
+		tokens.entries[TokenKey{ServerURL: server, ClientRef: "tenant-a", AccountID: acct}] =
+			&TokenEntry{AccessToken: "at-" + acct}
+	}
+	locks := &fakeRegistrationLocks{}
+
+	// trailing slash exercises normalization on the delete path
+	if err := deleteClient(context.Background(), clients, tokens, locks, server+"/", "tenant-a"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if tokens.filterDeletes != 1 {
+		t.Errorf("expected exactly 1 cascade DeleteByFilter, got %d", tokens.filterDeletes)
+	}
+	if len(tokens.entries) != 0 {
+		t.Errorf("expected all tenant-a tokens deleted, %d remain: %v", len(tokens.entries), tokens.entries)
+	}
+	if _, ok := clients.entries[ckey(server, "tenant-a")]; ok {
+		t.Errorf("client record not deleted; entries=%v", clients.entries)
+	}
+	if clients.deletes != 1 {
+		t.Errorf("expected exactly 1 client DeleteKey, got %d", clients.deletes)
+	}
+	// The registration lock must be acquired exactly once and released.
+	if locks.acquires != 1 || !locks.released() {
+		t.Errorf("lock acquires=%d released=%v, want 1/true", locks.acquires, locks.released())
+	}
+}
+
+// An empty clientRef is rejected: the dynamic slot cannot be deleted via this
+// API, and nothing is deleted.
+func TestDeleteClient_EmptyClientRefRejected(t *testing.T) {
+	clients := newFakeClientStore()
+	tokens := newFakeTokenStore()
+	locks := &fakeRegistrationLocks{}
+
+	err := deleteClient(context.Background(), clients, tokens, locks, "https://api.example.com", "")
+	if err == nil {
+		t.Fatal("expected an error when clientRef is empty")
+	}
+	if !errors.IsInvalidArgument(err) {
+		t.Errorf("expected InvalidArgument, got %v", err)
+	}
+	if tokens.filterDeletes != 0 || clients.deletes != 0 {
+		t.Errorf("must not delete on rejection; cascade=%d clientDeletes=%d", tokens.filterDeletes, clients.deletes)
+	}
+	// Validation must precede locking: an invalid request never takes the lock.
+	if locks.acquires != 0 {
+		t.Errorf("must not acquire the lock on rejection; acquires=%d", locks.acquires)
+	}
+}
+
+// A serverURL that normalizes to empty is rejected, and nothing is deleted.
+func TestDeleteClient_EmptyServerURLRejected(t *testing.T) {
+	clients := newFakeClientStore()
+	tokens := newFakeTokenStore()
+	locks := &fakeRegistrationLocks{}
+
+	err := deleteClient(context.Background(), clients, tokens, locks, "   ", "tenant-a")
+	if err == nil {
+		t.Fatal("expected an error when serverURL normalizes to empty")
+	}
+	if !errors.IsInvalidArgument(err) {
+		t.Errorf("expected InvalidArgument, got %v", err)
+	}
+	if tokens.filterDeletes != 0 || clients.deletes != 0 {
+		t.Errorf("must not delete on rejection; cascade=%d clientDeletes=%d", tokens.filterDeletes, clients.deletes)
+	}
+	if locks.acquires != 0 {
+		t.Errorf("must not acquire the lock on rejection; acquires=%d", locks.acquires)
+	}
+}
+
+// Deleting an already-absent client is not an error (idempotent): the NotFound
+// from the client delete is tolerated, and the token cascade still runs.
+func TestDeleteClient_IdempotentWhenClientAbsent(t *testing.T) {
+	clients := newFakeClientStore()
+	tokens := newFakeTokenStore()
+	locks := &fakeRegistrationLocks{}
+
+	if err := deleteClient(context.Background(), clients, tokens, locks, "https://api.example.com", "tenant-a"); err != nil {
+		t.Fatalf("deleting an absent client must be tolerated: %v", err)
+	}
+	if tokens.filterDeletes != 1 {
+		t.Errorf("cascade must still run for an absent client; filterDeletes=%d", tokens.filterDeletes)
+	}
+	if !locks.released() {
+		t.Error("lock must be released even on the idempotent (absent client) path")
+	}
+}
+
+// Deleting one tenant must leave another tenant's tokens and the dynamic slot's
+// tokens for the same server untouched.
+func TestDeleteClient_IsolatesOtherClients(t *testing.T) {
+	const server = "https://api.example.com"
+	clients := newFakeClientStore()
+	if err := registerStaticClient(context.Background(), clients, server, "tenant-a",
+		ClientEntry{ClientID: "id-a", ClientSecret: "shh"}); err != nil {
+		t.Fatalf("setup: tenant-a registration failed: %v", err)
+	}
+	if err := registerStaticClient(context.Background(), clients, server, "tenant-b",
+		ClientEntry{ClientID: "id-b", ClientSecret: "shh"}); err != nil {
+		t.Fatalf("setup: tenant-b registration failed: %v", err)
+	}
+
+	tokens := newFakeTokenStore()
+	tokens.entries[TokenKey{ServerURL: server, ClientRef: "tenant-a", AccountID: "acct-1"}] = &TokenEntry{AccessToken: "a"}
+	tokens.entries[TokenKey{ServerURL: server, ClientRef: "tenant-b", AccountID: "acct-1"}] = &TokenEntry{AccessToken: "b"}
+	// dynamic slot ("") token for the same server
+	tokens.entries[TokenKey{ServerURL: server, ClientRef: "", AccountID: "acct-1"}] = &TokenEntry{AccessToken: "d"}
+	locks := &fakeRegistrationLocks{}
+
+	if err := deleteClient(context.Background(), clients, tokens, locks, server, "tenant-a"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if _, ok := tokens.entries[(TokenKey{ServerURL: server, ClientRef: "tenant-a", AccountID: "acct-1"})]; ok {
+		t.Error("tenant-a token should have been deleted")
+	}
+	if _, ok := tokens.entries[(TokenKey{ServerURL: server, ClientRef: "tenant-b", AccountID: "acct-1"})]; !ok {
+		t.Error("tenant-b token must be untouched")
+	}
+	if _, ok := tokens.entries[(TokenKey{ServerURL: server, ClientRef: "", AccountID: "acct-1"})]; !ok {
+		t.Error("dynamic-slot token must be untouched")
+	}
+	// The tenant-b client record must also survive.
+	if _, ok := clients.entries[ckey(server, "tenant-b")]; !ok {
+		t.Error("tenant-b client record must be untouched")
+	}
+}
+
+// A failure in the token cascade aborts before the client record is deleted, so
+// no orphaned tokens are left pointing at a removed client. The error is wrapped
+// with the cascade's error code.
+func TestDeleteClient_CascadeFailureAbortsBeforeClientDelete(t *testing.T) {
+	const server = "https://api.example.com"
+	clients := newFakeClientStore()
+	if err := registerStaticClient(context.Background(), clients, server, "tenant-a",
+		ClientEntry{ClientID: "id-a", ClientSecret: "shh"}); err != nil {
+		t.Fatalf("setup: static registration failed: %v", err)
+	}
+	tokens := newFakeTokenStore()
+	tokens.filterDeleteErr = errors.Wrap(errors.Unknown, "boom")
+	locks := &fakeRegistrationLocks{}
+
+	err := deleteClient(context.Background(), clients, tokens, locks, server, "tenant-a")
+	if err == nil {
+		t.Fatal("expected an error when the token cascade fails")
+	}
+	if clients.deletes != 0 {
+		t.Errorf("client record must NOT be deleted when the cascade fails; deletes=%d", clients.deletes)
+	}
+	if _, ok := clients.entries[ckey(server, "tenant-a")]; !ok {
+		t.Error("client record must survive a cascade failure")
+	}
+	// The lock is taken before the cascade, so it must still be released on the
+	// cascade-failure path.
+	if !locks.released() {
+		t.Error("lock must be released even when the cascade fails")
+	}
+}
+
+// Lock contention must surface a retryable error and delete nothing: deleting
+// while a (re-)registration of the same client is in flight would race.
+func TestDeleteClient_LockContentionFailsRetryable(t *testing.T) {
+	const server = "https://api.example.com"
+	clients := newFakeClientStore()
+	if err := registerStaticClient(context.Background(), clients, server, "tenant-a",
+		ClientEntry{ClientID: "id-a", ClientSecret: "shh"}); err != nil {
+		t.Fatalf("setup: static registration failed: %v", err)
+	}
+	tokens := newFakeTokenStore()
+	tokens.entries[TokenKey{ServerURL: server, ClientRef: "tenant-a", AccountID: "acct-1"}] = &TokenEntry{AccessToken: "a"}
+	locks := &fakeRegistrationLocks{failWith: errors.Wrap(errors.AlreadyExists, "lock held")}
+
+	err := deleteClient(context.Background(), clients, tokens, locks, server, "tenant-a")
+	if err == nil {
+		t.Fatal("expected a retryable error on lock contention")
+	}
+	if errors.GetErrCode(err) != errors.AlreadyExists {
+		t.Errorf("expected a retryable (AlreadyExists) error on lock contention, got %v", err)
+	}
+	if tokens.filterDeletes != 0 {
+		t.Errorf("must not cascade-delete tokens when the lock is held; filterDeletes=%d", tokens.filterDeletes)
+	}
+	if clients.deletes != 0 {
+		t.Errorf("must not delete the client record when the lock is held; deletes=%d", clients.deletes)
+	}
+	if _, ok := tokens.entries[(TokenKey{ServerURL: server, ClientRef: "tenant-a", AccountID: "acct-1"})]; !ok {
+		t.Error("tenant-a token must survive a contended delete")
+	}
+}
+
 func TestMergeRegisterOptions_DefaultsAndOverrides(t *testing.T) {
 	cfg := testConfig()
 

--- a/oauth/token.go
+++ b/oauth/token.go
@@ -44,6 +44,15 @@ type tokenStore interface {
 	FindMany(ctx context.Context, filter any, offset, limit int32) ([]*TokenEntry, error)
 }
 
+// tokenDeleter is the subset of the token table the client-deletion cascade
+// needs: a bulk delete by filter. The concrete *table.Table[TokenKey, TokenEntry]
+// satisfies it; tests substitute a fake. The signature mirrors
+// core/table.Table.DeleteByFilter exactly — it returns (int64, error), not error
+// alone — so *table.Table is assignable to it; deleteClient ignores the count.
+type tokenDeleter interface {
+	DeleteByFilter(ctx context.Context, filter any) (int64, error)
+}
+
 // oauthErrorResponse is the RFC 6749 §5.2 token-endpoint error response. Parsed
 // to classify a non-2xx refresh outcome as permanent vs transient.
 type oauthErrorResponse struct {

--- a/oauth/token_test.go
+++ b/oauth/token_test.go
@@ -29,6 +29,10 @@ type fakeTokenStore struct {
 	deleteCalls int
 	lastFilter  any
 	deleteErr   error
+	// filterDeletes counts DeleteByFilter calls and filterDeleteErr, when set,
+	// makes DeleteByFilter fail — distinct from the point-delete deleteErr above.
+	filterDeletes   int
+	filterDeleteErr error
 }
 
 func newFakeTokenStore() *fakeTokenStore {
@@ -112,6 +116,42 @@ func (f *fakeTokenStore) FindMany(_ context.Context, filter any, _, _ int32) ([]
 		out = append(out, &cp)
 	}
 	return out, nil
+}
+
+// DeleteByFilter removes every entry matching the {_id.serverUrl, _id.clientRef}
+// equality filter the client-deletion cascade builds, returning the number
+// deleted. It satisfies the tokenDeleter interface used by deleteClient; the
+// matching mirrors FindMany's so the two stay consistent. The cascade only ever
+// passes a non-empty clientRef as a plain string, so only string equality is
+// modeled here.
+func (f *fakeTokenStore) DeleteByFilter(_ context.Context, filter any) (int64, error) {
+	f.filterDeletes++
+	f.lastFilter = filter
+	if f.filterDeleteErr != nil {
+		return 0, f.filterDeleteErr
+	}
+	want, byServer := "", false
+	matchRef := func(string) bool { return true }
+	if m, ok := filter.(bson.M); ok {
+		if s, ok := m["_id.serverUrl"].(string); ok {
+			want, byServer = s, true
+		}
+		if v, ok := m["_id.clientRef"].(string); ok {
+			matchRef = func(ref string) bool { return ref == v }
+		}
+	}
+	var deleted int64
+	for k := range f.entries {
+		if byServer && k.ServerURL != want {
+			continue
+		}
+		if !matchRef(k.ClientRef) {
+			continue
+		}
+		delete(f.entries, k)
+		deleted++
+	}
+	return deleted, nil
 }
 
 // jsonStatusResponse builds a JSON HTTP response with an explicit status code.


### PR DESCRIPTION
## Summary

Adds `OAuthManager.DeleteClient(ctx, serverURL, clientRef)` — the offboarding counterpart to `RegisterStaticClient` (Commit 3 of the OAuth Library Enhancements proposal, `AUTH-0015`). There was previously no public API to remove a client registration, and removing a static client (e.g. a tenant is offboarded) must also remove all of that client's tokens.

- Cascade-deletes every token for the `(serverURL, clientRef)` pair via `DeleteByFilter`, **then** deletes the client record. Ordering it this way means a partial failure never leaves orphaned tokens pointing at a deleted client.
- Restricted to **static** clients: an empty/whitespace `clientRef` is rejected (`InvalidArgument`) — the dynamic client slot (`""`) cannot be deleted via this API. An empty `serverURL` is likewise rejected.
- The token filter uses plain equality on a non-empty `clientRef`, avoiding the absent-or-empty subtlety that only affects the dynamic `""` case in `ListTokens`.
- A `NotFound` on the client-record delete is tolerated (idempotent) — the token cascade may still have done useful work.
- The cascade and the record delete run under the per-`(server, clientRef)` **registration lock**, mirroring `reRegisterClient`'s discipline, so a concurrent `RegisterStaticClient` / `ReRegisterClient` for the same client cannot interleave with the delete. Input validation runs first, so an invalid request never takes the lock; lock contention surfaces a retryable error.

### Interfaces

- `oauth/token.go`: new small `tokenDeleter` interface exposing `DeleteByFilter(ctx, filter any) (int64, error)` — signature matches `core/table.Table` exactly, so `*table.Table` satisfies it. The cascade ignores the returned count.

## Testing

- `go build ./...`
- `go vet ./oauth/...`
- `go test ./oauth/...`
- `golangci-lint run ./oauth/...` (0 issues)

New tests cover: cascade delete, empty-`clientRef` / empty-`serverURL` rejection (and that neither takes the lock), idempotent delete of an absent client, cross-tenant + dynamic-slot isolation, cascade-failure-aborts-before-record-delete, and lock-contention-is-retryable (deletes nothing).

Refs: AUTH-0015