### PR TITLE
feat(oauth): authenticate confidential clients at token endpoints

### DIFF
--- a/oauth/authorization.go
+++ b/oauth/authorization.go
@@ -87,7 +87,7 @@ func (m *OAuthManager) AuthorizationURL(ctx context.Context, opts AuthorizeOptio
 // authenticated session before calling this, and reject a mismatch, to prevent
 // login-CSRF / session-fixation.
 func (m *OAuthManager) HandleCallback(ctx context.Context, state string, code string) (*TokenEntry, error) {
-	return handleCallback(ctx, m.httpDo, m.serverTable, m.pendingTable, m.tokenTable, state, code)
+	return handleCallback(ctx, m.httpDo, m.serverTable, m.pendingTable, m.tokenTable, m.clientTable, state, code)
 }
 
 // authorizationURL implements AuthorizationURL against the
@@ -173,9 +173,10 @@ func authorizationURL(ctx context.Context, servers serverCache, clients clientSt
 }
 
 // handleCallback implements HandleCallback against the
-// pendingStore/serverCache/tokenWriter/httpDoFunc interfaces so it is
-// unit-testable with fakes.
-func handleCallback(ctx context.Context, do httpDoFunc, servers serverCache, pending pendingStore, tokens tokenWriter, state, code string) (*TokenEntry, error) {
+// pendingStore/serverCache/tokenWriter/clientStore/httpDoFunc interfaces so it is
+// unit-testable with fakes. The clientStore lets the exchange attach confidential
+// client authentication (client_secret_post) when the initiating client is one.
+func handleCallback(ctx context.Context, do httpDoFunc, servers serverCache, pending pendingStore, tokens tokenWriter, clients clientStore, state, code string) (*TokenEntry, error) {
 	if strings.TrimSpace(state) == "" {
 		return nil, errors.Wrap(errors.InvalidArgument, "oauth: callback state must not be empty")
 	}
@@ -213,18 +214,41 @@ func handleCallback(ctx context.Context, do httpDoFunc, servers serverCache, pen
 			"oauth: server %s has no usable token endpoint", ps.ServerURL)
 	}
 
-	// RFC 6749 §4.1.3 / RFC 7636 §4.5 authorization-code exchange for a public
-	// client, presenting the stored PKCE verifier. The client_id is the one that
-	// initiated the flow (persisted in the pending state), not whatever is
-	// currently registered: the authorization code is bound to the initiating
-	// client, so a re-registration between AuthorizationURL and HandleCallback
-	// must not change the client_id presented at the exchange.
+	// RFC 6749 §4.1.3 / RFC 7636 §4.5 authorization-code exchange, presenting the
+	// stored PKCE verifier. The client_id is the one that initiated the flow
+	// (persisted in the pending state), not whatever is currently registered: the
+	// authorization code is bound to the initiating client, so a re-registration
+	// between AuthorizationURL and HandleCallback must not change the client_id
+	// presented at the exchange.
 	form := url.Values{}
 	form.Set("grant_type", grantTypeAuthorizationCode)
 	form.Set("code", code)
 	form.Set("code_verifier", ps.CodeVerifier)
-	form.Set("client_id", ps.ClientID)
 	form.Set("redirect_uri", ps.RedirectURI)
+
+	// Attach client authentication. A confidential client must present its
+	// client_secret (client_secret_post) at the token endpoint, so look up the
+	// full ClientEntry by ps.ClientRef (the key field — NOT ps.ClientID, the
+	// protocol id). attachClientAuth is used only when the looked-up client still
+	// matches the client_id bound into the pending state; if the client is gone,
+	// the lookup errors, or the client_id changed (e.g. a re-registration mid-flow
+	// rotated it), fall back to public auth — send client_id only, never a stale
+	// secret, and never fail the exchange over it.
+	client, err := findClient(ctx, clients, ps.ServerURL, ps.ClientRef)
+	if err == nil && client != nil && client.ClientID == ps.ClientID {
+		attachClientAuth(form, client)
+	} else {
+		// Fall back to public auth (client_id only). A non-nil err here is a real
+		// store failure (findClient maps NotFound to nil/nil), not a benign miss:
+		// log it so a confidential client silently downgrading to a failing public
+		// exchange leaves a breadcrumb, rather than surfacing only as an opaque
+		// invalid_client from the token endpoint.
+		if err != nil {
+			log.Printf("oauth: client lookup failed during callback for %s/%s; using public auth: %s",
+				ps.ServerURL, ps.ClientRef, err)
+		}
+		form.Set("client_id", ps.ClientID)
+	}
 
 	var tr tokenResponse
 	if err := postForm(ctx, do, server.TokenEndpoint, form, &tr); err != nil {

--- a/oauth/authorization_test.go
+++ b/oauth/authorization_test.go
@@ -315,7 +315,7 @@ func TestHandleCallback_SuccessfulExchange(t *testing.T) {
 		return jsonResponse(tokenResp), nil
 	}
 
-	entry, err := handleCallback(context.Background(), do, servers, pending, tokens, "state-1", "auth-code-1")
+	entry, err := handleCallback(context.Background(), do, servers, pending, tokens, newFakeClientStore(), "state-1", "auth-code-1")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -390,7 +390,7 @@ func TestHandleCallback_UnknownState(t *testing.T) {
 		return nil, nil
 	}
 
-	_, err := handleCallback(context.Background(), do, servers, pending, tokens, "missing", "code")
+	_, err := handleCallback(context.Background(), do, servers, pending, tokens, newFakeClientStore(), "missing", "code")
 	if err == nil {
 		t.Fatal("expected error for unknown/expired state")
 	}
@@ -411,10 +411,11 @@ func TestHandleCallback_EmptyStateOrCode(t *testing.T) {
 		return nil, nil
 	}
 
-	if _, err := handleCallback(context.Background(), do, servers, pending, tokens, "", "code"); !errors.IsInvalidArgument(err) {
+	clients := newFakeClientStore()
+	if _, err := handleCallback(context.Background(), do, servers, pending, tokens, clients, "", "code"); !errors.IsInvalidArgument(err) {
 		t.Errorf("empty state: expected InvalidArgument, got %v", err)
 	}
-	if _, err := handleCallback(context.Background(), do, servers, pending, tokens, "state", ""); !errors.IsInvalidArgument(err) {
+	if _, err := handleCallback(context.Background(), do, servers, pending, tokens, clients, "state", ""); !errors.IsInvalidArgument(err) {
 		t.Errorf("empty code: expected InvalidArgument, got %v", err)
 	}
 }
@@ -438,7 +439,7 @@ func TestHandleCallback_ExchangeFailureKeepsPending(t *testing.T) {
 		return statusResponse(http.StatusBadRequest), nil
 	}
 
-	_, err := handleCallback(context.Background(), do, servers, pending, tokens, "state-1", "auth-code-1")
+	_, err := handleCallback(context.Background(), do, servers, pending, tokens, newFakeClientStore(), "state-1", "auth-code-1")
 	if err == nil {
 		t.Fatal("expected error when token exchange fails")
 	}
@@ -471,7 +472,7 @@ func TestHandleCallback_NoAccessToken(t *testing.T) {
 		return jsonResponse(`{"token_type":"Bearer","expires_in":3600}`), nil
 	}
 
-	_, err := handleCallback(context.Background(), do, servers, pending, tokens, "state-1", "auth-code-1")
+	_, err := handleCallback(context.Background(), do, servers, pending, tokens, newFakeClientStore(), "state-1", "auth-code-1")
 	if err == nil {
 		t.Fatal("expected error when response has no access_token")
 	}
@@ -504,7 +505,7 @@ func TestHandleCallback_ExpiredPendingState(t *testing.T) {
 		return nil, nil
 	}
 
-	_, err := handleCallback(context.Background(), do, servers, pending, tokens, "state-1", "auth-code-1")
+	_, err := handleCallback(context.Background(), do, servers, pending, tokens, newFakeClientStore(), "state-1", "auth-code-1")
 	if !errors.IsNotFound(err) {
 		t.Fatalf("expected NotFound for expired state, got %v", err)
 	}
@@ -571,7 +572,7 @@ func TestHandleCallback_ClientRefRoundTrip(t *testing.T) {
 	}
 
 	do := func(_ *http.Request) (*http.Response, error) { return jsonResponse(tokenResp), nil }
-	entry, err := handleCallback(context.Background(), do, servers, pending, tokens, params.State, "auth-code-1")
+	entry, err := handleCallback(context.Background(), do, servers, pending, tokens, clients, params.State, "auth-code-1")
 	if err != nil {
 		t.Fatalf("callback: %v", err)
 	}
@@ -587,6 +588,124 @@ func TestHandleCallback_ClientRefRoundTrip(t *testing.T) {
 	}
 	if _, ok := tokens.entries[TokenKey{ServerURL: "https://api.example.com", AccountID: "acct-1"}]; ok {
 		t.Error("token must not be stored under the dynamic (empty ClientRef) key")
+	}
+}
+
+// A confidential client must present client_secret on the auth-code exchange.
+// handleCallback looks the ClientEntry up by ps.ClientRef and, when its ClientID
+// matches the one bound into the pending state, attaches client_secret_post.
+func TestHandleCallback_ConfidentialSendsSecret(t *testing.T) {
+	servers := newFakeServerCache()
+	servers.entries["https://api.example.com"] = authServer()
+	clients := newFakeClientStore()
+	clients.entries[ckey("https://api.example.com", "tenant-a")] = &ClientEntry{
+		ClientID: "client-tenant-a", ClientSecret: "s3cret", ClientType: ClientTypeConfidential,
+	}
+	pending := newFakePendingStore()
+	seedPending(pending, "state-1", &PendingAuthState{
+		ServerURL:    "https://api.example.com",
+		ClientRef:    "tenant-a",
+		AccountID:    "acct-1",
+		ClientID:     "client-tenant-a",
+		CodeVerifier: "verifier-xyz",
+		RedirectURI:  "https://app.example.com/callback",
+	})
+	tokens := newFakeTokenWriter()
+
+	var sentForm url.Values
+	do := func(req *http.Request) (*http.Response, error) {
+		body, _ := io.ReadAll(req.Body)
+		sentForm, _ = url.ParseQuery(string(body))
+		return jsonResponse(tokenResp), nil
+	}
+
+	if _, err := handleCallback(context.Background(), do, servers, pending, tokens, clients, "state-1", "auth-code-1"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if sentForm.Get("client_id") != "client-tenant-a" {
+		t.Errorf("client_id = %q", sentForm.Get("client_id"))
+	}
+	if sentForm.Get("client_secret") != "s3cret" {
+		t.Errorf("confidential exchange must send client_secret, got %q", sentForm.Get("client_secret"))
+	}
+}
+
+// A public client must not present client_secret on the auth-code exchange.
+func TestHandleCallback_PublicNoSecret(t *testing.T) {
+	servers := newFakeServerCache()
+	servers.entries["https://api.example.com"] = authServer()
+	clients := newFakeClientStore()
+	clients.entries[ckey("https://api.example.com", "tenant-a")] = &ClientEntry{
+		ClientID: "client-tenant-a", ClientType: ClientTypePublic,
+	}
+	pending := newFakePendingStore()
+	seedPending(pending, "state-1", &PendingAuthState{
+		ServerURL:    "https://api.example.com",
+		ClientRef:    "tenant-a",
+		AccountID:    "acct-1",
+		ClientID:     "client-tenant-a",
+		CodeVerifier: "verifier-xyz",
+		RedirectURI:  "https://app.example.com/callback",
+	})
+	tokens := newFakeTokenWriter()
+
+	var sentForm url.Values
+	do := func(req *http.Request) (*http.Response, error) {
+		body, _ := io.ReadAll(req.Body)
+		sentForm, _ = url.ParseQuery(string(body))
+		return jsonResponse(tokenResp), nil
+	}
+
+	if _, err := handleCallback(context.Background(), do, servers, pending, tokens, clients, "state-1", "auth-code-1"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if sentForm.Get("client_id") != "client-tenant-a" {
+		t.Errorf("client_id = %q", sentForm.Get("client_id"))
+	}
+	if sentForm.Has("client_secret") {
+		t.Errorf("public exchange must not send client_secret, got %q", sentForm.Get("client_secret"))
+	}
+}
+
+// If the looked-up client's ClientID no longer matches the one bound into the
+// pending state (e.g. a re-registration rotated it mid-flow), handleCallback
+// falls back to public auth: it sends the pending-state client_id only, never a
+// stale secret, and does not fail the exchange.
+func TestHandleCallback_ClientIDMismatchFallsBack(t *testing.T) {
+	servers := newFakeServerCache()
+	servers.entries["https://api.example.com"] = authServer()
+	clients := newFakeClientStore()
+	// The currently-registered client carries a different (rotated) client_id and
+	// a secret; neither must leak into the exchange bound to the old client_id.
+	clients.entries[ckey("https://api.example.com", "tenant-a")] = &ClientEntry{
+		ClientID: "client-NEW", ClientSecret: "s3cret", ClientType: ClientTypeConfidential,
+	}
+	pending := newFakePendingStore()
+	seedPending(pending, "state-1", &PendingAuthState{
+		ServerURL:    "https://api.example.com",
+		ClientRef:    "tenant-a",
+		AccountID:    "acct-1",
+		ClientID:     "client-OLD",
+		CodeVerifier: "verifier-xyz",
+		RedirectURI:  "https://app.example.com/callback",
+	})
+	tokens := newFakeTokenWriter()
+
+	var sentForm url.Values
+	do := func(req *http.Request) (*http.Response, error) {
+		body, _ := io.ReadAll(req.Body)
+		sentForm, _ = url.ParseQuery(string(body))
+		return jsonResponse(tokenResp), nil
+	}
+
+	if _, err := handleCallback(context.Background(), do, servers, pending, tokens, clients, "state-1", "auth-code-1"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if sentForm.Get("client_id") != "client-OLD" {
+		t.Errorf("client_id must come from the pending state on mismatch, got %q", sentForm.Get("client_id"))
+	}
+	if sentForm.Has("client_secret") {
+		t.Errorf("must not send a stale secret on client_id mismatch, got %q", sentForm.Get("client_secret"))
 	}
 }
 

--- a/oauth/manager_e2e_test.go
+++ b/oauth/manager_e2e_test.go
@@ -182,7 +182,7 @@ func TestEndToEndFlow(t *testing.T) {
 	}
 
 	// 4. Callback — exchange the code, persist the token, consume pending state.
-	token, err := handleCallback(ctx, do, servers, pending, tokens, params.State, "auth-code-xyz")
+	token, err := handleCallback(ctx, do, servers, pending, tokens, clients, params.State, "auth-code-xyz")
 	if err != nil {
 		t.Fatalf("callback: %v", err)
 	}

--- a/oauth/token.go
+++ b/oauth/token.go
@@ -53,6 +53,22 @@ type tokenDeleter interface {
 	DeleteByFilter(ctx context.Context, filter any) (int64, error)
 }
 
+// attachClientAuth sets the client authentication parameters on a token-endpoint
+// request form. It always sends client_id; for a confidential client carrying a
+// non-empty secret it additionally sends client_secret (the client_secret_post
+// method, RFC 6749 §2.3.1). A public client — or a confidential client whose
+// secret is empty — sends client_id only.
+//
+// This is the single chokepoint the auth-code exchange, token refresh, and token
+// revocation paths all route through, so adding client_secret_basic (HTTP Basic)
+// later is a localized change here rather than at three call sites.
+func attachClientAuth(form url.Values, client *ClientEntry) {
+	form.Set("client_id", client.ClientID)
+	if client.ClientType == ClientTypeConfidential && client.ClientSecret != "" {
+		form.Set("client_secret", client.ClientSecret)
+	}
+}
+
 // oauthErrorResponse is the RFC 6749 §5.2 token-endpoint error response. Parsed
 // to classify a non-2xx refresh outcome as permanent vs transient.
 type oauthErrorResponse struct {
@@ -271,7 +287,7 @@ func refreshTokenExchange(ctx context.Context, do httpDoFunc, servers serverCach
 	form := url.Values{}
 	form.Set("grant_type", grantTypeRefreshToken)
 	form.Set("refresh_token", entry.RefreshToken)
-	form.Set("client_id", client.ClientID)
+	attachClientAuth(form, client)
 	// Deliberately omit `scope`: per RFC 6749 §6 an omitted scope means the new
 	// token keeps exactly the scope originally granted — the same result echoing
 	// the stored scopes would aim for, but without tripping authorization servers
@@ -395,7 +411,7 @@ func revokeAtServer(ctx context.Context, do httpDoFunc, servers serverCache, cli
 		return err
 	}
 	if client != nil {
-		form.Set("client_id", client.ClientID)
+		attachClientAuth(form, client)
 	}
 
 	return postRevocation(ctx, do, server.RevocationEndpoint, form)

--- a/oauth/token_test.go
+++ b/oauth/token_test.go
@@ -488,6 +488,109 @@ func TestRefreshTokenExchange_Success(t *testing.T) {
 	}
 }
 
+// attachClientAuth is the single chokepoint for token-endpoint client
+// authentication: a confidential client with a non-empty secret sends
+// client_secret_post; a public client — or a confidential client whose secret is
+// empty — sends client_id only.
+func TestAttachClientAuth(t *testing.T) {
+	cases := []struct {
+		name       string
+		client     *ClientEntry
+		wantSecret string // "" means client_secret must be absent
+	}{
+		{
+			name:       "confidential with secret sends client_secret",
+			client:     &ClientEntry{ClientID: "client-abc", ClientSecret: "s3cret", ClientType: ClientTypeConfidential},
+			wantSecret: "s3cret",
+		},
+		{
+			name:       "public sends client_id only",
+			client:     &ClientEntry{ClientID: "client-abc", ClientType: ClientTypePublic},
+			wantSecret: "",
+		},
+		{
+			name:       "confidential with empty secret sends no client_secret",
+			client:     &ClientEntry{ClientID: "client-abc", ClientType: ClientTypeConfidential},
+			wantSecret: "",
+		},
+		{
+			name:       "public ignores a stray secret",
+			client:     &ClientEntry{ClientID: "client-abc", ClientSecret: "leftover", ClientType: ClientTypePublic},
+			wantSecret: "",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			form := url.Values{}
+			attachClientAuth(form, tc.client)
+			if form.Get("client_id") != "client-abc" {
+				t.Errorf("client_id = %q, want client-abc", form.Get("client_id"))
+			}
+			if tc.wantSecret == "" {
+				if form.Has("client_secret") {
+					t.Errorf("client_secret must be absent, got %q", form.Get("client_secret"))
+				}
+			} else if form.Get("client_secret") != tc.wantSecret {
+				t.Errorf("client_secret = %q, want %q", form.Get("client_secret"), tc.wantSecret)
+			}
+		})
+	}
+}
+
+// A confidential client must present client_secret on the refresh exchange.
+func TestRefreshTokenExchange_ConfidentialSendsSecret(t *testing.T) {
+	servers := newFakeServerCache()
+	servers.entries["https://api.example.com"] = revServer()
+	clients := newFakeClientStore()
+	clients.entries["https://api.example.com"] = &ClientEntry{
+		ClientID: "client-abc", ClientSecret: "s3cret", ClientType: ClientTypeConfidential,
+	}
+
+	var sentForm url.Values
+	do := func(req *http.Request) (*http.Response, error) {
+		body, _ := io.ReadAll(req.Body)
+		sentForm, _ = url.ParseQuery(string(body))
+		return jsonResponse(tokenResp), nil
+	}
+
+	prev := &TokenEntry{AccessToken: "old", RefreshToken: "rt-old", State: SessionActive}
+	if _, err := refreshTokenExchange(context.Background(), do, servers, clients, testTokenKey(), prev); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if sentForm.Get("client_id") != "client-abc" {
+		t.Errorf("client_id = %q", sentForm.Get("client_id"))
+	}
+	if sentForm.Get("client_secret") != "s3cret" {
+		t.Errorf("confidential refresh must send client_secret, got %q", sentForm.Get("client_secret"))
+	}
+}
+
+// A public client must not present client_secret on the refresh exchange.
+func TestRefreshTokenExchange_PublicNoSecret(t *testing.T) {
+	servers := newFakeServerCache()
+	servers.entries["https://api.example.com"] = revServer()
+	clients := newFakeClientStore()
+	clients.entries["https://api.example.com"] = &ClientEntry{ClientID: "client-abc", ClientType: ClientTypePublic}
+
+	var sentForm url.Values
+	do := func(req *http.Request) (*http.Response, error) {
+		body, _ := io.ReadAll(req.Body)
+		sentForm, _ = url.ParseQuery(string(body))
+		return jsonResponse(tokenResp), nil
+	}
+
+	prev := &TokenEntry{AccessToken: "old", RefreshToken: "rt-old", State: SessionActive}
+	if _, err := refreshTokenExchange(context.Background(), do, servers, clients, testTokenKey(), prev); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if sentForm.Get("client_id") != "client-abc" {
+		t.Errorf("client_id = %q", sentForm.Get("client_id"))
+	}
+	if sentForm.Has("client_secret") {
+		t.Errorf("public refresh must not send client_secret, got %q", sentForm.Get("client_secret"))
+	}
+}
+
 // A refresh response that omits refresh_token must retain the prior one.
 func TestRefreshTokenExchange_KeepsPriorRefreshToken(t *testing.T) {
 	servers := newFakeServerCache()
@@ -621,6 +724,62 @@ func TestRevokeToken_Success(t *testing.T) {
 	}
 	if tokens.entries[*testTokenKey()].State != SessionRevoked {
 		t.Errorf("token must be marked revoked locally")
+	}
+}
+
+// A confidential client must present client_secret on the revocation request.
+func TestRevokeToken_ConfidentialSendsSecret(t *testing.T) {
+	tokens := newFakeTokenStore()
+	tokens.entries[*testTokenKey()] = &TokenEntry{AccessToken: "at", RefreshToken: "rt", State: SessionActive}
+	servers := newFakeServerCache()
+	servers.entries["https://api.example.com"] = revServer()
+	clients := newFakeClientStore()
+	clients.entries["https://api.example.com"] = &ClientEntry{
+		ClientID: "client-abc", ClientSecret: "s3cret", ClientType: ClientTypeConfidential,
+	}
+
+	var sentForm url.Values
+	do := func(req *http.Request) (*http.Response, error) {
+		body, _ := io.ReadAll(req.Body)
+		sentForm, _ = url.ParseQuery(string(body))
+		return statusResponse(http.StatusOK), nil
+	}
+
+	if err := revokeToken(context.Background(), tokens, do, servers, clients, "https://api.example.com", "", "acct-1"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if sentForm.Get("client_id") != "client-abc" {
+		t.Errorf("client_id = %q", sentForm.Get("client_id"))
+	}
+	if sentForm.Get("client_secret") != "s3cret" {
+		t.Errorf("confidential revocation must send client_secret, got %q", sentForm.Get("client_secret"))
+	}
+}
+
+// A public client must not present client_secret on the revocation request.
+func TestRevokeToken_PublicNoSecret(t *testing.T) {
+	tokens := newFakeTokenStore()
+	tokens.entries[*testTokenKey()] = &TokenEntry{AccessToken: "at", RefreshToken: "rt", State: SessionActive}
+	servers := newFakeServerCache()
+	servers.entries["https://api.example.com"] = revServer()
+	clients := newFakeClientStore()
+	clients.entries["https://api.example.com"] = &ClientEntry{ClientID: "client-abc", ClientType: ClientTypePublic}
+
+	var sentForm url.Values
+	do := func(req *http.Request) (*http.Response, error) {
+		body, _ := io.ReadAll(req.Body)
+		sentForm, _ = url.ParseQuery(string(body))
+		return statusResponse(http.StatusOK), nil
+	}
+
+	if err := revokeToken(context.Background(), tokens, do, servers, clients, "https://api.example.com", "", "acct-1"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if sentForm.Get("client_id") != "client-abc" {
+		t.Errorf("client_id = %q", sentForm.Get("client_id"))
+	}
+	if sentForm.Has("client_secret") {
+		t.Errorf("public revocation must not send client_secret, got %q", sentForm.Get("client_secret"))
 	}
 }
 


### PR DESCRIPTION
## Summary

Confidential clients must authenticate at the token endpoint. Previously every token-endpoint interaction assumed a public client and sent only `client_id`. This adds `client_secret_post` support (Commit 4 of the OAuth Library Enhancements proposal, `AUTH-0016`): when a client is `ClientTypeConfidential` with a non-empty secret, `client_secret` is included in the form body alongside `client_id` for auth-code exchange, token refresh, and token revocation. `client_secret_basic` (HTTP Basic) remains an explicit follow-up, out of scope here.

## Changes

- **`attachClientAuth` helper (`oauth/token.go`)** — the single chokepoint all three token-endpoint paths route through. Always sets `client_id`; adds `client_secret` only for a confidential client carrying a non-empty secret (RFC 6749 §2.3.1). A public client — or a confidential client with an empty secret — sends `client_id` only. Adding `client_secret_basic` later is a localized change here.
- **Auth-code exchange (`handleCallback`)** — gains a `clients clientStore` parameter; `HandleCallback` threads `m.clientTable` through. It looks up the full `ClientEntry` by `ps.ClientRef` (the key field, **not** `ps.ClientID`, the protocol id) and only attaches auth when `client != nil && client.ClientID == ps.ClientID`. If the client is gone, the lookup errors, or the `client_id` changed mid-flow (e.g. a re-registration rotated it), it falls back to public auth — sends `client_id` only, never a stale secret, and never fails the exchange. A genuine store error on that lookup is logged so a confidential client silently downgrading leaves a breadcrumb.
- **Token refresh (`refreshTokenExchange`)** and **revocation (`revokeAtServer`)** — replace the bare `client_id` set with `attachClientAuth`; revocation keeps it inside the existing `if client != nil` guard.

## Testing

- `go build ./...`
- `go vet ./oauth/...`
- `go test ./...`
- `gofmt -l` (clean)
- `golangci-lint run ./oauth/...` (0 issues)

New tests cover `attachClientAuth` directly (confidential-with-secret, public, confidential-empty-secret, public-with-stray-secret) plus confidential / public / client_id-mismatch-fallback cases across all three token-endpoint paths.

Refs: AUTH-0016

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Refined OAuth authorization code exchange to properly authenticate confidential clients with secure credentials while maintaining public client support
  * Enhanced fallback mechanism to gracefully handle scenarios where client information changes between authorization and token exchange
  * Improved error logging for failed client lookups during token requests

<!-- end of auto-generated comment: release notes by coderabbit.ai -->