### PR TITLE
feat(oauth): capture refresh capability explicitly via RefreshPolicy

### DIFF
--- a/oauth/authorization.go
+++ b/oauth/authorization.go
@@ -299,6 +299,15 @@ func newTokenEntry(tr *tokenResponse, ps *PendingAuthState, now time.Time) *Toke
 		State:        SessionActive,
 		LastRefresh:  now.Unix(),
 	}
+	// Capture refresh capability explicitly from the response: a refresh token
+	// means the session is refreshable; its absence means the server issued a
+	// non-refreshable (e.g. offline) token that must not later trip a permanent
+	// refresh failure on a transiently-blanked field.
+	if strings.TrimSpace(tr.RefreshToken) != "" {
+		entry.RefreshPolicy = RefreshPolicyRefreshable
+	} else {
+		entry.RefreshPolicy = RefreshPolicyNoRefresh
+	}
 	if tr.ExpiresIn > 0 {
 		entry.ExpiresAt = now.Add(time.Duration(tr.ExpiresIn) * time.Second).Unix()
 	}

--- a/oauth/authorization_test.go
+++ b/oauth/authorization_test.go
@@ -723,3 +723,20 @@ func TestNewTokenEntry_ScopeFallback(t *testing.T) {
 		t.Errorf("State = %q", entry.State)
 	}
 }
+
+// newTokenEntry must capture refresh capability explicitly from the response: a
+// refresh token means Refreshable; its absence means NoRefresh, so a later forced
+// refresh cannot wrongly revoke a non-refreshable (offline) token.
+func TestNewTokenEntry_RefreshPolicy(t *testing.T) {
+	ps := &PendingAuthState{Scopes: []string{"read"}}
+
+	withRT := newTokenEntry(&tokenResponse{AccessToken: "at", RefreshToken: "rt"}, ps, time.Now())
+	if withRT.RefreshPolicy != RefreshPolicyRefreshable {
+		t.Errorf("RefreshPolicy = %d, want Refreshable when a refresh token is present", withRT.RefreshPolicy)
+	}
+
+	noRT := newTokenEntry(&tokenResponse{AccessToken: "at"}, ps, time.Now())
+	if noRT.RefreshPolicy != RefreshPolicyNoRefresh {
+		t.Errorf("RefreshPolicy = %d, want NoRefresh when the response omits a refresh token", noRT.RefreshPolicy)
+	}
+}

--- a/oauth/encryption_test.go
+++ b/oauth/encryption_test.go
@@ -35,13 +35,14 @@ func storedString(t *testing.T, v interface{}, field string) string {
 
 func TestTokenEntryEncryptionRoundTrip(t *testing.T) {
 	orig := &TokenEntry{
-		AccessToken:  "super-secret-access-token",
-		TokenType:    "Bearer",
-		RefreshToken: "super-secret-refresh-token",
-		IDToken:      "super-secret-id-token",
-		ExpiresAt:    123456,
-		Scopes:       []string{"read", "write"},
-		State:        SessionActive,
+		AccessToken:   "super-secret-access-token",
+		TokenType:     "Bearer",
+		RefreshToken:  "super-secret-refresh-token",
+		IDToken:       "super-secret-id-token",
+		ExpiresAt:     123456,
+		Scopes:        []string{"read", "write"},
+		State:         SessionActive,
+		RefreshPolicy: RefreshPolicyNoRefresh,
 	}
 
 	data, err := bson.Marshal(orig)
@@ -77,6 +78,47 @@ func TestTokenEntryEncryptionRoundTrip(t *testing.T) {
 	// Non-encrypted fields survive the round-trip.
 	if got.TokenType != orig.TokenType || got.State != orig.State || got.ExpiresAt != orig.ExpiresAt {
 		t.Errorf("non-encrypted fields not preserved: %+v", got)
+	}
+	// RefreshPolicy must persist through the custom (encrypting) marshaler — a new
+	// field on a custom-marshaled struct is silently dropped if the alias pattern
+	// is not used, which would resurrect the empty-token inference bug.
+	if got.RefreshPolicy != orig.RefreshPolicy {
+		t.Errorf("RefreshPolicy not preserved: got %d, want %d", got.RefreshPolicy, orig.RefreshPolicy)
+	}
+}
+
+// A legacy token document persisted before the RefreshPolicy field existed has no
+// refreshPolicy key; it must decode to the zero value RefreshPolicyRefreshable —
+// the correct default that keeps pre-existing refreshable sessions refreshable
+// (no migration shim required).
+func TestTokenEntry_LegacyDocDefaultsToRefreshable(t *testing.T) {
+	// A document written without the refreshPolicy field. Encrypt AccessToken the
+	// same way the marshaler would so UnmarshalBSON's decrypt step succeeds.
+	enc := getEncryptor()
+	ciphertext, err := enc.EncryptString("legacy-access-token")
+	if err != nil {
+		t.Fatalf("encrypt failed: %v", err)
+	}
+	legacy := bson.M{
+		"accessToken": ciphertext,
+		"tokenType":   "Bearer",
+		"state":       int32(SessionActive),
+		// no refreshPolicy key — as written by code predating this field
+	}
+	data, err := bson.Marshal(legacy)
+	if err != nil {
+		t.Fatalf("marshal failed: %v", err)
+	}
+
+	var got TokenEntry
+	if err := bson.Unmarshal(data, &got); err != nil {
+		t.Fatalf("unmarshal failed: %v", err)
+	}
+	if got.RefreshPolicy != RefreshPolicyRefreshable {
+		t.Errorf("legacy doc RefreshPolicy = %d, want Refreshable (0)", got.RefreshPolicy)
+	}
+	if got.AccessToken != "legacy-access-token" {
+		t.Errorf("legacy doc AccessToken = %q, want decrypted plaintext", got.AccessToken)
 	}
 }
 

--- a/oauth/reconciler.go
+++ b/oauth/reconciler.go
@@ -149,6 +149,18 @@ func (r *tokenRefreshReconciler) Reconcile(k any) (*reconciler.Result, error) {
 	}
 
 	now := time.Now()
+
+	// A NoRefresh token must never be auto-refreshed. With no expiry there is
+	// nothing left to track — stop reconciling entirely so offline tokens are
+	// not churned forever. With an expiry, keep requeuing for state bookkeeping
+	// but never attempt a refresh.
+	if entry.RefreshPolicy == RefreshPolicyNoRefresh {
+		if entry.ExpiresAt == 0 {
+			return nil, nil
+		}
+		return &reconciler.Result{RequeueAfter: timeUntilRefresh(entry, now)}, nil
+	}
+
 	if !tokenNeedsRefresh(entry, now) {
 		// healthy — re-check when it approaches the refresh threshold
 		return &reconciler.Result{RequeueAfter: timeUntilRefresh(entry, now)}, nil

--- a/oauth/reconciler_test.go
+++ b/oauth/reconciler_test.go
@@ -167,6 +167,51 @@ func TestTokenReconciler_RevokedIsDead(t *testing.T) {
 	}
 }
 
+// A NoRefresh token with no expiry must stop reconciling entirely so offline
+// tokens (no expiry, no refresh token) are never churned.
+func TestTokenReconciler_NoRefreshNoExpiryStops(t *testing.T) {
+	ft := newFakeTokenTable()
+	ft.entries[*tokenKey()] = &TokenEntry{State: SessionActive, RefreshPolicy: RefreshPolicyNoRefresh, ExpiresAt: 0}
+	fl := &fakeLocker{}
+	r := &tokenRefreshReconciler{tokens: ft, locks: fl, refresh: failRefresh(t)}
+
+	res, err := r.Reconcile(tokenKey())
+	if err != nil || res != nil {
+		t.Fatalf("NoRefresh + no expiry must stop reconciling, got res=%+v err=%v", res, err)
+	}
+	if fl.acquired != 0 {
+		t.Errorf("NoRefresh token must not acquire the refresh lock")
+	}
+}
+
+// A NoRefresh token with a (near) expiry must keep requeuing for bookkeeping but
+// never acquire the lock or attempt a refresh — a refresh attempt would fail and
+// wrongly revoke a valid session.
+func TestTokenReconciler_NoRefreshWithExpiryRequeuesWithoutRefresh(t *testing.T) {
+	ft := newFakeTokenTable()
+	// Near expiry: a Refreshable token here would be refreshed; NoRefresh must not.
+	ft.entries[*tokenKey()] = &TokenEntry{
+		State: SessionActive, RefreshPolicy: RefreshPolicyNoRefresh,
+		ExpiresAt: time.Now().Add(time.Minute).Unix(),
+	}
+	fl := &fakeLocker{}
+	r := &tokenRefreshReconciler{tokens: ft, locks: fl, refresh: failRefresh(t)}
+
+	res, err := r.Reconcile(tokenKey())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if res == nil || res.RequeueAfter <= 0 {
+		t.Errorf("NoRefresh + expiry should requeue with a positive delay, got %+v", res)
+	}
+	if fl.acquired != 0 {
+		t.Errorf("NoRefresh token must not acquire the refresh lock")
+	}
+	if ft.updateCalls != 0 {
+		t.Errorf("NoRefresh token must not be updated, got %d updates", ft.updateCalls)
+	}
+}
+
 func TestTokenReconciler_HealthyRequeues(t *testing.T) {
 	ft := newFakeTokenTable()
 	ft.entries[*tokenKey()] = &TokenEntry{State: SessionActive, ExpiresAt: time.Now().Add(time.Hour).Unix()}

--- a/oauth/token.go
+++ b/oauth/token.go
@@ -214,6 +214,13 @@ func lockedRefresh(ctx context.Context, tokens tokenStore, locks refreshLockerAP
 	if entry.State == SessionRevoked {
 		return entry, nil
 	}
+	// A NoRefresh token must never be refreshed — not even under a forced
+	// refresh. Short-circuit before the exchange so ForceRefresh on a Shopify
+	// style offline token (no expiry, no refresh token) cannot trip
+	// errPermanentRefresh and revoke a valid session.
+	if entry.RefreshPolicy == RefreshPolicyNoRefresh {
+		return entry, nil
+	}
 	if !force && !tokenNeedsRefresh(entry, time.Now()) {
 		return entry, nil
 	}
@@ -259,9 +266,16 @@ func lockedRefresh(ctx context.Context, tokens tokenStore, locks refreshLockerAP
 // invalid_grant / invalid_client response, is a permanent failure
 // (errPermanentRefresh); other failures are transient.
 func refreshTokenExchange(ctx context.Context, do httpDoFunc, servers serverCache, clients clientStore, key *TokenKey, entry *TokenEntry) (*TokenEntry, error) {
+	if entry.RefreshPolicy == RefreshPolicyNoRefresh {
+		// The server issued a non-refreshable token (e.g. an offline token with
+		// no expiry). There is nothing to refresh — a normal terminal state, not
+		// a failure: hand the entry back unchanged so the caller does not revoke
+		// a perfectly valid session.
+		return entry, nil
+	}
 	if strings.TrimSpace(entry.RefreshToken) == "" {
-		// No refresh token to present — the session can only be restored by a
-		// fresh authorization, so treat it as permanent.
+		// Policy says refreshable but the token is missing — a genuine permanent
+		// failure: the session can only be restored by a fresh authorization.
 		return nil, fmt.Errorf("oauth: no refresh token stored for %s: %w",
 			key.id(), errPermanentRefresh)
 	}
@@ -318,7 +332,12 @@ func refreshedTokenEntry(prev *TokenEntry, tr *tokenResponse, now time.Time) *To
 	}
 	if tr.RefreshToken != "" {
 		updated.RefreshToken = tr.RefreshToken
+		updated.RefreshPolicy = RefreshPolicyRefreshable
 	}
+	// Deliberately do NOT downgrade RefreshPolicy to NoRefresh when the response
+	// omits a refresh token: per RFC 6749 §6 the existing refresh token stays
+	// valid, so a refreshable session remains refreshable. The policy is carried
+	// over from prev via the struct copy above.
 	if tr.IDToken != "" {
 		updated.IDToken = tr.IDToken
 	}

--- a/oauth/token_test.go
+++ b/oauth/token_test.go
@@ -433,6 +433,29 @@ func TestLockedRefresh_RevokeDuringExchangeWins(t *testing.T) {
 	}
 }
 
+// A NoRefresh token must short-circuit lockedRefresh even on the forced path:
+// ForceRefresh on a Shopify-style offline token (no expiry, no refresh token)
+// must return the entry as-is, never invoke the exchange, and never drive a
+// permanent-refresh revocation.
+func TestLockedRefresh_NoRefreshShortCircuits(t *testing.T) {
+	tokens := newFakeTokenStore()
+	tokens.entries[*testTokenKey()] = &TokenEntry{
+		AccessToken: "offline-at", RefreshPolicy: RefreshPolicyNoRefresh, State: SessionActive,
+	}
+	locks := &fakeLocker{}
+
+	got, err := lockedRefresh(context.Background(), tokens, locks, failRefresh(t), testTokenKey(), true)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got.AccessToken != "offline-at" || got.State != SessionActive {
+		t.Errorf("NoRefresh token must be returned unchanged, got %+v", got)
+	}
+	if tokens.updateCalls != 0 {
+		t.Errorf("NoRefresh token must not be persisted/refreshed, got %d updates", tokens.updateCalls)
+	}
+}
+
 // --- refresh exchange + error classification ---
 
 func TestRefreshTokenExchange_Success(t *testing.T) {
@@ -651,6 +674,67 @@ func TestRefreshTokenExchange_NoRefreshTokenIsPermanent(t *testing.T) {
 	_, err := refreshTokenExchange(context.Background(), do, servers, clients, testTokenKey(), prev)
 	if !errors.Is(err, errPermanentRefresh) {
 		t.Fatalf("a missing refresh token must be a permanent failure, got %v", err)
+	}
+}
+
+// A NoRefresh entry must short-circuit the exchange: it returns the entry as-is
+// with no error and never touches the network. Regression test for Shopify-style
+// offline tokens (no expiry, no refresh token) being wrongly revoked.
+func TestRefreshTokenExchange_NoRefreshPolicyReturnsEntry(t *testing.T) {
+	servers := newFakeServerCache()
+	clients := newFakeClientStore()
+	do := func(req *http.Request) (*http.Response, error) {
+		t.Fatalf("a NoRefresh token must not hit the network: %s", req.URL)
+		return nil, nil
+	}
+	entry := &TokenEntry{AccessToken: "offline-at", RefreshPolicy: RefreshPolicyNoRefresh, State: SessionActive}
+	got, err := refreshTokenExchange(context.Background(), do, servers, clients, testTokenKey(), entry)
+	if err != nil {
+		t.Fatalf("NoRefresh must not be an error, got %v", err)
+	}
+	if got != entry {
+		t.Errorf("NoRefresh must return the entry unchanged")
+	}
+}
+
+// A Refreshable entry whose refresh token is empty is a genuine permanent
+// failure: the policy promised refreshability but the token is gone, so only a
+// fresh authorization can restore the session.
+func TestRefreshTokenExchange_RefreshableEmptyTokenIsPermanent(t *testing.T) {
+	servers := newFakeServerCache()
+	clients := newFakeClientStore()
+	do := func(req *http.Request) (*http.Response, error) {
+		t.Fatalf("must not call the network without a refresh token: %s", req.URL)
+		return nil, nil
+	}
+	entry := &TokenEntry{AccessToken: "old", RefreshPolicy: RefreshPolicyRefreshable, State: SessionActive} // no RefreshToken
+	_, err := refreshTokenExchange(context.Background(), do, servers, clients, testTokenKey(), entry)
+	if !errors.Is(err, errPermanentRefresh) {
+		t.Fatalf("Refreshable + empty token must be permanent, got %v", err)
+	}
+}
+
+// refreshedTokenEntry must capture refresh capability without ever downgrading
+// it: a response carrying a refresh token sets Refreshable; one that omits it
+// keeps the prior policy (RFC 6749 §6 — the existing refresh token stays valid).
+func TestRefreshedTokenEntry_RefreshPolicy(t *testing.T) {
+	// omitted refresh_token must NOT downgrade a Refreshable entry
+	prev := &TokenEntry{
+		AccessToken: "old", RefreshToken: "rt-keep",
+		RefreshPolicy: RefreshPolicyRefreshable, State: SessionActive,
+	}
+	kept := refreshedTokenEntry(prev, &tokenResponse{AccessToken: "at-new"}, time.Now())
+	if kept.RefreshPolicy != RefreshPolicyRefreshable {
+		t.Errorf("RefreshPolicy = %d, want Refreshable retained on omitted refresh_token", kept.RefreshPolicy)
+	}
+	if kept.RefreshToken != "rt-keep" {
+		t.Errorf("prior refresh token must be retained, got %q", kept.RefreshToken)
+	}
+
+	// a response carrying a refresh_token sets Refreshable explicitly
+	got := refreshedTokenEntry(&TokenEntry{State: SessionActive}, &tokenResponse{AccessToken: "at", RefreshToken: "rt-new"}, time.Now())
+	if got.RefreshPolicy != RefreshPolicyRefreshable {
+		t.Errorf("RefreshPolicy = %d, want Refreshable when the response carries a refresh token", got.RefreshPolicy)
 	}
 }
 

--- a/oauth/types.go
+++ b/oauth/types.go
@@ -147,8 +147,14 @@ type TokenEntry struct {
 	Scopes       []string     `bson:"scopes,omitempty"`
 	IDToken      string       `bson:"idToken,omitempty"` // encrypted at rest
 	State        SessionState `bson:"state"`
-	LastRefresh  int64        `bson:"lastRefresh,omitempty"`
-	ErrorReason  string       `bson:"errorReason,omitempty"`
+	// RefreshPolicy records whether this token may be silently refreshed,
+	// captured explicitly from the server response at exchange time rather than
+	// inferred from an empty RefreshToken (a blanked field is not a reliable
+	// signal). Legacy documents written before this field default to
+	// RefreshPolicyRefreshable (the zero value) on decode, the correct default.
+	RefreshPolicy RefreshPolicy `bson:"refreshPolicy"`
+	LastRefresh   int64         `bson:"lastRefresh,omitempty"`
+	ErrorReason   string        `bson:"errorReason,omitempty"`
 }
 
 // --- pending_auth_states ---


### PR DESCRIPTION
## Summary

Refresh behavior was inferred from an empty `RefreshToken` field, but absence of data is not a reliable signal — a transient error or partial response can blank the field. For Shopify-style offline tokens (no expiry, no refresh token), `ForceRefresh` then incorrectly tripped `errPermanentRefresh` and revoked a valid session. This captures refresh capability explicitly at token-exchange time from the server response via a stored `RefreshPolicy` (Commit 5 of the OAuth Library Enhancements proposal, `AUTH-0017`). The `RefreshPolicy` enum itself was defined in AUTH-0013; this PR adds the field and all set/check logic.

## Changes

- **`TokenEntry.RefreshPolicy` (`oauth/types.go`)** — new field, `bson:"refreshPolicy"`. It carries no `omitempty`, and legacy documents written before it decode to the zero value `RefreshPolicyRefreshable` — the correct default, so no migration shim is needed. It flows through `TokenEntry`'s custom encrypting BSON marshaler unchanged (the `type alias` pattern re-serializes the whole struct).
- **Set — `newTokenEntry` (`oauth/authorization.go`)** — a response carrying a refresh token sets `Refreshable`; its absence sets `NoRefresh`.
- **Set — `refreshedTokenEntry` (`oauth/token.go`)** — a refresh token in the response sets `Refreshable`; an omitted one **never downgrades** the policy (RFC 6749 §6: the existing refresh token stays valid), carried over via the struct copy.
- **Check — `refreshTokenExchange` (`oauth/token.go`)** — `NoRefresh` short-circuits and returns the entry unchanged with no error (a normal terminal state, not a failure); `Refreshable` with an empty token is a genuine `errPermanentRefresh`.
- **Check — `lockedRefresh` (`oauth/token.go`)** — `NoRefresh` short-circuits before the exchange, even on a forced refresh, so `ForceRefresh` on an offline token cannot revoke a valid session.
- **Check — `reconciler.go`** — `NoRefresh` + no expiry stops reconciling entirely (offline tokens are never churned); `NoRefresh` + an expiry requeues for bookkeeping but never attempts a refresh.

## Testing

- `go build ./...`, `go vet ./oauth/...`, `go test ./...` — all pass
- `gofmt -l oauth/` clean; `golangci-lint run ./oauth/...` — 0 issues

New tests cover: `newTokenEntry` and `refreshedTokenEntry` policy set (incl. no-downgrade), `refreshTokenExchange` `NoRefresh`-returns-entry (offline-token revocation regression) and `Refreshable`+empty-token-is-permanent, `lockedRefresh` `NoRefresh` short-circuit under forced refresh, reconciler `NoRefresh`+no-expiry-stops / +expiry-requeues-without-refresh, plus a BSON round-trip assertion and a legacy-doc-defaults-to-Refreshable test.

Refs: AUTH-0017