### PR TITLE
Add RegistrationEndpoint and InitialAccessToken to RegisterClientOptions

### DIFF
--- a/oauth/registration.go
+++ b/oauth/registration.go
@@ -242,9 +242,9 @@ func performRegistration(ctx context.Context, do httpDoFunc, clients clientStore
 
 	var resp clientRegistrationResponse
 	if merged.InitialAccessToken != "" {
-		// When an initial access token is required, build the HTTP request
-		// directly so the Authorization header is scoped to registration only
-		// (Option A from issue #42). This avoids changing postJSON's signature.
+		// When an initial access token is required, attach the Bearer header
+		// via postJSONWithAuth (which shares the core logic with postJSON via
+		// doPostJSON). See RFC 7591 §3.1.
 		if err := postJSONWithAuth(ctx, do, endpoint, merged.InitialAccessToken, &reqBody, &resp); err != nil {
 			return nil, errors.Wrapf(errors.GetErrCode(err),
 				"oauth: dynamic client registration failed for %s: %s", normalized, err)
@@ -433,11 +433,13 @@ func preferStrings(primary, fallback []string) []string {
 	return fallback
 }
 
-// postJSON marshals payload, POSTs it as application/json, and decodes a JSON
-// response body into out, wrapping network, HTTP-status, and parse failures with
-// core/errors codes. The response body is bounded by maxMetadataBytes (defined
-// in discovery.go) so a hostile server cannot exhaust memory.
-func postJSON(ctx context.Context, do httpDoFunc, url string, payload, out any) error {
+// doPostJSON is the shared implementation for posting JSON payloads. It marshals
+// payload, POSTs it as application/json, applies any extra headers from the map,
+// and decodes a JSON response body into out, wrapping network, HTTP-status, and
+// parse failures with core/errors codes. The response body is bounded by
+// maxMetadataBytes (defined in discovery.go) so a hostile server cannot exhaust
+// memory.
+func doPostJSON(ctx context.Context, do httpDoFunc, url string, extraHeaders map[string]string, payload, out any) error {
 	body, err := json.Marshal(payload)
 	if err != nil {
 		return errors.Wrapf(errors.InvalidArgument, "oauth: failed to encode request for %s: %s", url, err)
@@ -448,6 +450,9 @@ func postJSON(ctx context.Context, do httpDoFunc, url string, payload, out any) 
 	}
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("Accept", "application/json")
+	for k, v := range extraHeaders {
+		req.Header.Set(k, v)
+	}
 
 	resp, err := do(req)
 	if err != nil {
@@ -476,45 +481,21 @@ func postJSON(ctx context.Context, do httpDoFunc, url string, payload, out any) 
 	return nil
 }
 
+// postJSON marshals payload, POSTs it as application/json, and decodes a JSON
+// response body into out, wrapping network, HTTP-status, and parse failures with
+// core/errors codes. The response body is bounded by maxMetadataBytes (defined
+// in discovery.go) so a hostile server cannot exhaust memory.
+//
+// Delegates to doPostJSON with no extra headers.
+func postJSON(ctx context.Context, do httpDoFunc, url string, payload, out any) error {
+	return doPostJSON(ctx, do, url, nil, payload, out)
+}
+
 // postJSONWithAuth is like postJSON but additionally sets an Authorization:
 // Bearer header on the outbound request. Used by performRegistration when the
-// caller supplies an InitialAccessToken per RFC 7591 §3.1. Keeping this as a
-// separate function (rather than adding an optional parameter to postJSON)
-// avoids touching postJSON's signature and keeps the auth concern local to
-// registration.
+// caller supplies an InitialAccessToken per RFC 7591 §3.1.
+//
+// Delegates to doPostJSON with an Authorization header.
 func postJSONWithAuth(ctx context.Context, do httpDoFunc, url, bearerToken string, payload, out any) error {
-	body, err := json.Marshal(payload)
-	if err != nil {
-		return errors.Wrapf(errors.InvalidArgument, "oauth: failed to encode request for %s: %s", url, err)
-	}
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(body))
-	if err != nil {
-		return errors.Wrapf(errors.InvalidArgument, "oauth: failed to build request for %s: %s", url, err)
-	}
-	req.Header.Set("Content-Type", "application/json")
-	req.Header.Set("Accept", "application/json")
-	req.Header.Set("Authorization", "Bearer "+bearerToken)
-
-	resp, err := do(req)
-	if err != nil {
-		return errors.Wrapf(errors.Unknown, "oauth: request to %s failed: %s", url, err)
-	}
-	limited := io.LimitReader(resp.Body, maxMetadataBytes)
-	defer func() {
-		_, _ = io.Copy(io.Discard, limited)
-		_ = resp.Body.Close()
-	}()
-
-	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
-		return errors.Wrapf(errors.Unknown, "oauth: %s returned HTTP status %d", url, resp.StatusCode)
-	}
-
-	raw, err := io.ReadAll(limited)
-	if err != nil {
-		return errors.Wrapf(errors.Unknown, "oauth: failed to read response from %s: %s", url, err)
-	}
-	if err := json.Unmarshal(raw, out); err != nil {
-		return errors.Wrapf(errors.InvalidArgument, "oauth: failed to parse JSON from %s: %s", url, err)
-	}
-	return nil
+	return doPostJSON(ctx, do, url, map[string]string{"Authorization": "Bearer " + bearerToken}, payload, out)
 }

--- a/oauth/registration.go
+++ b/oauth/registration.go
@@ -211,14 +211,23 @@ func reRegisterClient(ctx context.Context, do httpDoFunc, clients clientStore, l
 // should be returned from cache first (fast-path / double-check, or a delete for
 // re-registration).
 func performRegistration(ctx context.Context, do httpDoFunc, clients clientStore, discover discoverFunc, merged RegisterClientOptions, normalized, clientRef string) (*ClientEntry, error) {
-	// Ensure we have server metadata, specifically the registration endpoint.
+	// Resolve the registration endpoint: prefer the caller-supplied override,
+	// fall back to the discovered metadata.
+	endpoint := merged.RegistrationEndpoint
+
+	// Always run discovery to obtain other metadata (TokenEndpoint,
+	// AuthorizationEndpoint, etc.) that the rest of the library needs.
 	server, err := discover(ctx, normalized)
 	if err != nil {
 		return nil, err
 	}
-	if server.RegistrationEndpoint == "" {
+
+	if endpoint == "" {
+		endpoint = server.RegistrationEndpoint
+	}
+	if endpoint == "" {
 		return nil, errors.Wrapf(errors.InvalidArgument,
-			"oauth: server %s does not advertise a registration endpoint", normalized)
+			"oauth: no registration endpoint for %s (not in caller options and not discovered)", normalized)
 	}
 
 	// RFC 7591 dynamic registration for a public client.
@@ -230,10 +239,21 @@ func performRegistration(ctx context.Context, do httpDoFunc, clients clientStore
 		TokenEndpointAuthMethod: TokenEndpointAuthMethodNone,
 		Scope:                   strings.Join(merged.Scopes, " "),
 	}
+
 	var resp clientRegistrationResponse
-	if err := postJSON(ctx, do, server.RegistrationEndpoint, &reqBody, &resp); err != nil {
-		return nil, errors.Wrapf(errors.GetErrCode(err),
-			"oauth: dynamic client registration failed for %s: %s", normalized, err)
+	if merged.InitialAccessToken != "" {
+		// When an initial access token is required, build the HTTP request
+		// directly so the Authorization header is scoped to registration only
+		// (Option A from issue #42). This avoids changing postJSON's signature.
+		if err := postJSONWithAuth(ctx, do, endpoint, merged.InitialAccessToken, &reqBody, &resp); err != nil {
+			return nil, errors.Wrapf(errors.GetErrCode(err),
+				"oauth: dynamic client registration failed for %s: %s", normalized, err)
+		}
+	} else {
+		if err := postJSON(ctx, do, endpoint, &reqBody, &resp); err != nil {
+			return nil, errors.Wrapf(errors.GetErrCode(err),
+				"oauth: dynamic client registration failed for %s: %s", normalized, err)
+		}
 	}
 	if resp.ClientID == "" {
 		return nil, errors.Wrapf(errors.InvalidArgument,
@@ -386,7 +406,8 @@ func findClient(ctx context.Context, clients clientStore, normalized, clientRef 
 
 // mergeRegisterOptions fills unset RegisterClientOptions fields from the manager
 // configuration: ClientName, RedirectURIs (from the single RedirectURI), and
-// Scopes.
+// Scopes. RegistrationEndpoint and InitialAccessToken are per-call fields with
+// no config-level defaults — they are copied through unchanged.
 func mergeRegisterOptions(cfg OAuthConfig, opts RegisterClientOptions) RegisterClientOptions {
 	merged := opts
 	if merged.ClientName == "" {
@@ -398,6 +419,8 @@ func mergeRegisterOptions(cfg OAuthConfig, opts RegisterClientOptions) RegisterC
 	if len(merged.Scopes) == 0 {
 		merged.Scopes = cfg.Scopes
 	}
+	// RegistrationEndpoint and InitialAccessToken are per-call overrides with
+	// no config-level defaults; they propagate via the struct copy above.
 	return merged
 }
 
@@ -433,6 +456,49 @@ func postJSON(ctx context.Context, do httpDoFunc, url string, payload, out any) 
 	// Share one maxMetadataBytes budget across the parse read and the deferred
 	// drain so the body can never read more than that in total, while still
 	// draining (bounded) on every path so the connection can be reused.
+	limited := io.LimitReader(resp.Body, maxMetadataBytes)
+	defer func() {
+		_, _ = io.Copy(io.Discard, limited)
+		_ = resp.Body.Close()
+	}()
+
+	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
+		return errors.Wrapf(errors.Unknown, "oauth: %s returned HTTP status %d", url, resp.StatusCode)
+	}
+
+	raw, err := io.ReadAll(limited)
+	if err != nil {
+		return errors.Wrapf(errors.Unknown, "oauth: failed to read response from %s: %s", url, err)
+	}
+	if err := json.Unmarshal(raw, out); err != nil {
+		return errors.Wrapf(errors.InvalidArgument, "oauth: failed to parse JSON from %s: %s", url, err)
+	}
+	return nil
+}
+
+// postJSONWithAuth is like postJSON but additionally sets an Authorization:
+// Bearer header on the outbound request. Used by performRegistration when the
+// caller supplies an InitialAccessToken per RFC 7591 §3.1. Keeping this as a
+// separate function (rather than adding an optional parameter to postJSON)
+// avoids touching postJSON's signature and keeps the auth concern local to
+// registration.
+func postJSONWithAuth(ctx context.Context, do httpDoFunc, url, bearerToken string, payload, out any) error {
+	body, err := json.Marshal(payload)
+	if err != nil {
+		return errors.Wrapf(errors.InvalidArgument, "oauth: failed to encode request for %s: %s", url, err)
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(body))
+	if err != nil {
+		return errors.Wrapf(errors.InvalidArgument, "oauth: failed to build request for %s: %s", url, err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", "application/json")
+	req.Header.Set("Authorization", "Bearer "+bearerToken)
+
+	resp, err := do(req)
+	if err != nil {
+		return errors.Wrapf(errors.Unknown, "oauth: request to %s failed: %s", url, err)
+	}
 	limited := io.LimitReader(resp.Body, maxMetadataBytes)
 	defer func() {
 		_, _ = io.Copy(io.Discard, limited)

--- a/oauth/registration_test.go
+++ b/oauth/registration_test.go
@@ -412,6 +412,198 @@ func TestRegisterDynamicClient_NoRegistrationEndpoint(t *testing.T) {
 	}
 }
 
+// --- RegistrationEndpoint override tests ---
+
+// When RegistrationEndpoint is set, performRegistration must POST to it instead
+// of the discovered endpoint.
+func TestRegisterDynamicClient_ExplicitRegistrationEndpoint(t *testing.T) {
+	locks := &fakeRegistrationLocks{}
+	clients := newFakeClientStore()
+
+	var sawURL string
+	do := func(req *http.Request) (*http.Response, error) {
+		sawURL = req.URL.String()
+		return jsonResponse(regResp), nil
+	}
+
+	entry, err := registerDynamicClient(context.Background(), do, clients, locks,
+		staticDiscover(discoveredServer()), testConfig(),
+		RegisterClientOptions{
+			ServerURL:            "https://api.example.com",
+			RegistrationEndpoint: "https://custom.example.com/register",
+		})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if entry.ClientID != "client-abc" {
+		t.Errorf("client id = %q", entry.ClientID)
+	}
+	if sawURL != "https://custom.example.com/register" {
+		t.Errorf("registration POST URL = %q, want https://custom.example.com/register", sawURL)
+	}
+}
+
+// When the discovered server has no registration endpoint but the caller
+// supplies one via RegistrationEndpoint, registration must succeed.
+func TestRegisterDynamicClient_ExplicitEndpointRescuesNoDiscovery(t *testing.T) {
+	locks := &fakeRegistrationLocks{}
+	clients := newFakeClientStore()
+
+	var sawURL string
+	do := func(req *http.Request) (*http.Response, error) {
+		sawURL = req.URL.String()
+		return jsonResponse(regResp), nil
+	}
+
+	// Discovery yields no registration endpoint — this would normally fail.
+	noRegServer := &ServerEntry{TokenEndpoint: "https://as.example.com/token"}
+
+	entry, err := registerDynamicClient(context.Background(), do, clients, locks,
+		staticDiscover(noRegServer), testConfig(),
+		RegisterClientOptions{
+			ServerURL:            "https://api.example.com",
+			RegistrationEndpoint: "https://custom.example.com/register",
+		})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if entry.ClientID != "client-abc" {
+		t.Errorf("client id = %q", entry.ClientID)
+	}
+	if sawURL != "https://custom.example.com/register" {
+		t.Errorf("registration POST URL = %q, want https://custom.example.com/register", sawURL)
+	}
+}
+
+// --- InitialAccessToken tests ---
+
+// When InitialAccessToken is set, the registration request must carry an
+// Authorization: Bearer header.
+func TestRegisterDynamicClient_InitialAccessToken(t *testing.T) {
+	locks := &fakeRegistrationLocks{}
+	clients := newFakeClientStore()
+
+	var sawAuthHeader string
+	do := func(req *http.Request) (*http.Response, error) {
+		sawAuthHeader = req.Header.Get("Authorization")
+		return jsonResponse(regResp), nil
+	}
+
+	entry, err := registerDynamicClient(context.Background(), do, clients, locks,
+		staticDiscover(discoveredServer()), testConfig(),
+		RegisterClientOptions{
+			ServerURL:          "https://api.example.com",
+			InitialAccessToken: "iat-secret-token",
+		})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if entry.ClientID != "client-abc" {
+		t.Errorf("client id = %q", entry.ClientID)
+	}
+	if sawAuthHeader != "Bearer iat-secret-token" {
+		t.Errorf("Authorization header = %q, want %q", sawAuthHeader, "Bearer iat-secret-token")
+	}
+}
+
+// When InitialAccessToken is NOT set, the registration request must NOT carry
+// an Authorization header.
+func TestRegisterDynamicClient_NoInitialAccessToken_NoAuthHeader(t *testing.T) {
+	locks := &fakeRegistrationLocks{}
+	clients := newFakeClientStore()
+
+	var sawAuthHeader string
+	do := func(req *http.Request) (*http.Response, error) {
+		sawAuthHeader = req.Header.Get("Authorization")
+		return jsonResponse(regResp), nil
+	}
+
+	_, err := registerDynamicClient(context.Background(), do, clients, locks,
+		staticDiscover(discoveredServer()), testConfig(),
+		RegisterClientOptions{ServerURL: "https://api.example.com"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if sawAuthHeader != "" {
+		t.Errorf("Authorization header = %q, want empty (no initial access token)", sawAuthHeader)
+	}
+}
+
+// Both RegistrationEndpoint and InitialAccessToken set: the request must POST
+// to the explicit endpoint with the Bearer header.
+func TestRegisterDynamicClient_ExplicitEndpointAndInitialAccessToken(t *testing.T) {
+	locks := &fakeRegistrationLocks{}
+	clients := newFakeClientStore()
+
+	var sawURL string
+	var sawAuthHeader string
+	do := func(req *http.Request) (*http.Response, error) {
+		sawURL = req.URL.String()
+		sawAuthHeader = req.Header.Get("Authorization")
+		return jsonResponse(regResp), nil
+	}
+
+	noRegServer := &ServerEntry{TokenEndpoint: "https://as.example.com/token"}
+
+	entry, err := registerDynamicClient(context.Background(), do, clients, locks,
+		staticDiscover(noRegServer), testConfig(),
+		RegisterClientOptions{
+			ServerURL:            "https://api.example.com",
+			RegistrationEndpoint: "https://custom.example.com/register",
+			InitialAccessToken:   "iat-token-42",
+		})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if entry.ClientID != "client-abc" {
+		t.Errorf("client id = %q", entry.ClientID)
+	}
+	if sawURL != "https://custom.example.com/register" {
+		t.Errorf("registration POST URL = %q, want https://custom.example.com/register", sawURL)
+	}
+	if sawAuthHeader != "Bearer iat-token-42" {
+		t.Errorf("Authorization header = %q, want %q", sawAuthHeader, "Bearer iat-token-42")
+	}
+}
+
+// ReRegisterClient must respect RegistrationEndpoint and InitialAccessToken
+// identically to RegisterDynamicClient (it delegates to performRegistration).
+func TestReRegisterClient_RespectsExplicitEndpointAndToken(t *testing.T) {
+	locks := &fakeRegistrationLocks{}
+	clients := newFakeClientStore()
+	clients.entries["https://api.example.com"] = &ClientEntry{ClientID: "stale"}
+
+	var sawURL string
+	var sawAuthHeader string
+	do := func(req *http.Request) (*http.Response, error) {
+		sawURL = req.URL.String()
+		sawAuthHeader = req.Header.Get("Authorization")
+		return jsonResponse(regResp), nil
+	}
+
+	noRegServer := &ServerEntry{TokenEndpoint: "https://as.example.com/token"}
+
+	entry, err := reRegisterClient(context.Background(), do, clients, locks,
+		staticDiscover(noRegServer), testConfig(),
+		RegisterClientOptions{
+			ServerURL:            "https://api.example.com",
+			RegistrationEndpoint: "https://custom.example.com/register",
+			InitialAccessToken:   "iat-re-register",
+		})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if entry.ClientID != "client-abc" {
+		t.Errorf("expected freshly-registered client, got %q", entry.ClientID)
+	}
+	if sawURL != "https://custom.example.com/register" {
+		t.Errorf("re-registration POST URL = %q, want https://custom.example.com/register", sawURL)
+	}
+	if sawAuthHeader != "Bearer iat-re-register" {
+		t.Errorf("Authorization header = %q, want %q", sawAuthHeader, "Bearer iat-re-register")
+	}
+}
+
 func TestReRegisterClient_DeletesThenRegisters(t *testing.T) {
 	locks := &fakeRegistrationLocks{}
 	clients := newFakeClientStore()
@@ -1008,5 +1200,35 @@ func TestMergeRegisterOptions_DefaultsAndOverrides(t *testing.T) {
 	}
 	if strings.Join(got.Scopes, ",") != "openid" {
 		t.Errorf("override Scopes = %v", got.Scopes)
+	}
+}
+
+// RegistrationEndpoint and InitialAccessToken must propagate through merge
+// unchanged (no config-level defaults).
+func TestMergeRegisterOptions_PropagatesEndpointAndToken(t *testing.T) {
+	cfg := testConfig()
+
+	// When set, both fields pass through.
+	got := mergeRegisterOptions(cfg, RegisterClientOptions{
+		ServerURL:            "https://api.example.com",
+		RegistrationEndpoint: "https://custom.example.com/register",
+		InitialAccessToken:   "iat-abc",
+	})
+	if got.RegistrationEndpoint != "https://custom.example.com/register" {
+		t.Errorf("RegistrationEndpoint = %q, want https://custom.example.com/register", got.RegistrationEndpoint)
+	}
+	if got.InitialAccessToken != "iat-abc" {
+		t.Errorf("InitialAccessToken = %q, want iat-abc", got.InitialAccessToken)
+	}
+
+	// When not set, both remain empty (no defaults from config).
+	got = mergeRegisterOptions(cfg, RegisterClientOptions{
+		ServerURL: "https://api.example.com",
+	})
+	if got.RegistrationEndpoint != "" {
+		t.Errorf("RegistrationEndpoint = %q, want empty (no config default)", got.RegistrationEndpoint)
+	}
+	if got.InitialAccessToken != "" {
+		t.Errorf("InitialAccessToken = %q, want empty (no config default)", got.InitialAccessToken)
 	}
 }

--- a/oauth/types.go
+++ b/oauth/types.go
@@ -230,6 +230,18 @@ type RegisterClientOptions struct {
 	RedirectURIs []string // defaults to []string{OAuthConfig.RedirectURI}
 	Scopes       []string // defaults to OAuthConfig.Scopes
 	// GrantTypes defaults to ["authorization_code", "refresh_token"]
+
+	// RegistrationEndpoint, when non-empty, is used directly as the RFC 7591
+	// registration endpoint, bypassing the discovered
+	// ServerEntry.RegistrationEndpoint. This supports providers that expose a
+	// registration endpoint but do not advertise it via .well-known metadata.
+	RegistrationEndpoint string
+
+	// InitialAccessToken, when non-empty, is sent as an Authorization: Bearer
+	// header on the RFC 7591 registration request, per RFC 7591 §3.1. This
+	// supports providers that require an initial access token to create a
+	// client.
+	InitialAccessToken string
 }
 
 // AuthorizeOptions parameterizes generation of an authorization request.


### PR DESCRIPTION
## Summary

Closes #42.

Adds two optional fields to `RegisterClientOptions` so callers can:

- **`RegistrationEndpoint`** — supply an explicit RFC 7591 registration endpoint, bypassing the discovered `ServerEntry.RegistrationEndpoint`. This supports providers that expose a registration endpoint but do not advertise it via `.well-known` metadata.
- **`InitialAccessToken`** — attach an `Authorization: Bearer` header on the registration request per RFC 7591 §3.1. This supports providers that require an initial access token to create a client.

### Design decisions

- **Option A** (from #42): A new `postJSONWithAuth` helper builds the HTTP request directly with the Bearer header, keeping the auth concern scoped to registration without changing `postJSON`'s signature.
- Discovery always runs even when an explicit endpoint is supplied, because the rest of the library needs the discovered metadata (TokenEndpoint, AuthorizationEndpoint, etc.).
- Both fields are per-call overrides with no `OAuthConfig`-level defaults — they propagate through `mergeRegisterOptions` via the struct copy unchanged.
- No database/storage changes: these fields are consumed at call time only and never flow into `ClientEntry`.

### Files changed

| File | Change |
|------|--------|
| `oauth/types.go` | Added `RegistrationEndpoint` and `InitialAccessToken` fields to `RegisterClientOptions` |
| `oauth/registration.go` | Updated `performRegistration` endpoint resolution + auth branching; added `postJSONWithAuth`; documented new fields in `mergeRegisterOptions` |
| `oauth/registration_test.go` | Added 7 new test functions covering explicit endpoint, initial access token, both combined, regression guards, re-register path, and merge propagation |

## Test plan

- [ ] `TestRegisterDynamicClient_ExplicitRegistrationEndpoint` — POST goes to custom endpoint
- [ ] `TestRegisterDynamicClient_ExplicitEndpointRescuesNoDiscovery` — explicit endpoint succeeds when discovery yields no registration endpoint
- [ ] `TestRegisterDynamicClient_InitialAccessToken` — `Authorization: Bearer` header is set
- [ ] `TestRegisterDynamicClient_NoInitialAccessToken_NoAuthHeader` — regression: no auth header when token not set
- [ ] `TestRegisterDynamicClient_ExplicitEndpointAndInitialAccessToken` — both fields combined
- [ ] `TestReRegisterClient_RespectsExplicitEndpointAndToken` — re-register path respects both fields
- [ ] `TestMergeRegisterOptions_PropagatesEndpointAndToken` — merge propagates fields, no config defaults
- [ ] All existing tests pass unchanged (backward compatible)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added per-call support for overriding the RFC 7591 client registration endpoint.
  * Added per-call support for sending an initial access token via an `Authorization: Bearer ...` header during dynamic client registration.
* **Tests**
  * Added coverage verifying explicit endpoint usage, discovery fallback behavior, and conditional inclusion (or omission) of the Bearer token header, including re-registration and option merging.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->