### PR TITLE
feat: add per-server TokenResponseMappers to OAuthConfig

### DIFF
--- a/oauth/authorization.go
+++ b/oauth/authorization.go
@@ -59,6 +59,43 @@ type tokenResponse struct {
 	IDToken      string `json:"id_token"`
 }
 
+// tokenResponseMapperFunc is the function signature for the optional
+// TokenResponseMapper callback. It is defined here for readability in the
+// internal function signatures.
+type tokenResponseMapperFunc func(raw []byte) (*TokenResponse, error)
+
+// tokenResponseFromPublic converts a public TokenResponse (returned by a
+// consumer-supplied TokenResponseMapper) into the internal tokenResponse used
+// by the library's exchange and persistence logic.
+func tokenResponseFromPublic(pub *TokenResponse) tokenResponse {
+	return tokenResponse{
+		AccessToken:  pub.AccessToken,
+		TokenType:    pub.TokenType,
+		ExpiresIn:    pub.ExpiresIn,
+		RefreshToken: pub.RefreshToken,
+		Scope:        pub.Scope,
+		IDToken:      pub.IDToken,
+	}
+}
+
+// applyTokenResponseMapper calls the consumer-supplied mapper when the standard
+// token-endpoint parse yielded an empty AccessToken. It is the shared mapper
+// application logic used by both handleCallback and refreshTokenExchange.
+func applyTokenResponseMapper(mapper tokenResponseMapperFunc, raw []byte, tr *tokenResponse, serverURL string) error {
+	if tr.AccessToken != "" || mapper == nil {
+		return nil
+	}
+	mapped, err := mapper(raw)
+	if err != nil {
+		return errors.Wrapf(errors.InvalidArgument,
+			"oauth: token response mapper failed for %s: %s", serverURL, err)
+	}
+	if mapped != nil {
+		*tr = tokenResponseFromPublic(mapped)
+	}
+	return nil
+}
+
 // AuthorizationURL builds the Authorization Code + PKCE request parameters for a
 // remote server and persists the transient state needed to complete the flow. It
 // generates a PKCE verifier/challenge (S256) and a CSRF state token, stores a
@@ -87,7 +124,7 @@ func (m *OAuthManager) AuthorizationURL(ctx context.Context, opts AuthorizeOptio
 // authenticated session before calling this, and reject a mismatch, to prevent
 // login-CSRF / session-fixation.
 func (m *OAuthManager) HandleCallback(ctx context.Context, state string, code string) (*TokenEntry, error) {
-	return handleCallback(ctx, m.httpDo, m.serverTable, m.pendingTable, m.tokenTable, m.clientTable, state, code)
+	return handleCallback(ctx, m.httpDo, m.serverTable, m.pendingTable, m.tokenTable, m.clientTable, state, code, m.config.TokenResponseMapper)
 }
 
 // authorizationURL implements AuthorizationURL against the
@@ -176,7 +213,7 @@ func authorizationURL(ctx context.Context, servers serverCache, clients clientSt
 // pendingStore/serverCache/tokenWriter/clientStore/httpDoFunc interfaces so it is
 // unit-testable with fakes. The clientStore lets the exchange attach confidential
 // client authentication (client_secret_post) when the initiating client is one.
-func handleCallback(ctx context.Context, do httpDoFunc, servers serverCache, pending pendingStore, tokens tokenWriter, clients clientStore, state, code string) (*TokenEntry, error) {
+func handleCallback(ctx context.Context, do httpDoFunc, servers serverCache, pending pendingStore, tokens tokenWriter, clients clientStore, state, code string, mapper tokenResponseMapperFunc) (*TokenEntry, error) {
 	if strings.TrimSpace(state) == "" {
 		return nil, errors.Wrap(errors.InvalidArgument, "oauth: callback state must not be empty")
 	}
@@ -251,9 +288,13 @@ func handleCallback(ctx context.Context, do httpDoFunc, servers serverCache, pen
 	}
 
 	var tr tokenResponse
-	if err := postForm(ctx, do, server.TokenEndpoint, form, &tr); err != nil {
+	raw, err := postForm(ctx, do, server.TokenEndpoint, form, &tr)
+	if err != nil {
 		return nil, errors.Wrapf(errors.GetErrCode(err),
 			"oauth: authorization code exchange failed for %s: %s", ps.ServerURL, err)
+	}
+	if err := applyTokenResponseMapper(mapper, raw, &tr, ps.ServerURL); err != nil {
+		return nil, err
 	}
 	if tr.AccessToken == "" {
 		return nil, errors.Wrapf(errors.InvalidArgument,
@@ -351,18 +392,19 @@ func codeChallengeS256(verifier string) string {
 // core/errors codes. The token endpoint takes form-encoded input (RFC 6749
 // §4.1.3) but returns JSON (§5.1). The response body is bounded by
 // maxMetadataBytes (defined in discovery.go) so a hostile server cannot exhaust
-// memory.
-func postForm(ctx context.Context, do httpDoFunc, endpoint string, form url.Values, out any) error {
+// memory. The raw response bytes are returned alongside so callers can apply a
+// TokenResponseMapper when the standard parse yields an empty access_token.
+func postForm(ctx context.Context, do httpDoFunc, endpoint string, form url.Values, out any) ([]byte, error) {
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint, strings.NewReader(form.Encode()))
 	if err != nil {
-		return errors.Wrapf(errors.InvalidArgument, "oauth: failed to build request for %s: %s", endpoint, err)
+		return nil, errors.Wrapf(errors.InvalidArgument, "oauth: failed to build request for %s: %s", endpoint, err)
 	}
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 	req.Header.Set("Accept", "application/json")
 
 	resp, err := do(req)
 	if err != nil {
-		return errors.Wrapf(errors.Unknown, "oauth: request to %s failed: %s", endpoint, err)
+		return nil, errors.Wrapf(errors.Unknown, "oauth: request to %s failed: %s", endpoint, err)
 	}
 	// Share one maxMetadataBytes budget across the parse read and the deferred
 	// drain so the body can never read more than that in total, while still
@@ -374,15 +416,15 @@ func postForm(ctx context.Context, do httpDoFunc, endpoint string, form url.Valu
 	}()
 
 	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
-		return errors.Wrapf(errors.Unknown, "oauth: %s returned HTTP status %d", endpoint, resp.StatusCode)
+		return nil, errors.Wrapf(errors.Unknown, "oauth: %s returned HTTP status %d", endpoint, resp.StatusCode)
 	}
 
 	raw, err := io.ReadAll(limited)
 	if err != nil {
-		return errors.Wrapf(errors.Unknown, "oauth: failed to read response from %s: %s", endpoint, err)
+		return nil, errors.Wrapf(errors.Unknown, "oauth: failed to read response from %s: %s", endpoint, err)
 	}
 	if err := json.Unmarshal(raw, out); err != nil {
-		return errors.Wrapf(errors.InvalidArgument, "oauth: failed to parse JSON from %s: %s", endpoint, err)
+		return nil, errors.Wrapf(errors.InvalidArgument, "oauth: failed to parse JSON from %s: %s", endpoint, err)
 	}
-	return nil
+	return raw, nil
 }

--- a/oauth/authorization.go
+++ b/oauth/authorization.go
@@ -59,34 +59,22 @@ type tokenResponse struct {
 	IDToken      string `json:"id_token"`
 }
 
-// tokenResponseMappers is the type for the optional per-server-URL mapper map.
-// It is defined here for readability in the internal function signatures.
-type tokenResponseMappers map[string]func(raw []byte) (*TokenResponse, error)
-
-// tokenResponseFromPublic converts a public TokenResponse (returned by a
-// consumer-supplied TokenResponseMapper) into the internal tokenResponse used
-// by the library's exchange and persistence logic.
-func tokenResponseFromPublic(pub *TokenResponse) tokenResponse {
-	return tokenResponse{
-		AccessToken:  pub.AccessToken,
-		TokenType:    pub.TokenType,
-		ExpiresIn:    pub.ExpiresIn,
-		RefreshToken: pub.RefreshToken,
-		Scope:        pub.Scope,
-		IDToken:      pub.IDToken,
-	}
-}
-
 // applyTokenResponseMapper looks up the consumer-supplied mapper for the given
 // serverURL and calls it when the standard token-endpoint parse yielded an empty
 // AccessToken. It is the shared mapper application logic used by both
 // handleCallback and refreshTokenExchange.
-func applyTokenResponseMapper(mappers tokenResponseMappers, raw []byte, tr *tokenResponse, serverURL string) error {
+//
+// When the mapper returns a non-nil *TokenResponse, its fields are merged
+// field-by-field: only non-zero values overwrite the corresponding field in tr.
+// This preserves fields the standard JSON parse already populated correctly
+// (e.g. token_type, expires_in) when the mapper only extracts the missing piece
+// (e.g. access_token from a provider-specific nested object).
+func applyTokenResponseMapper(mappers *TokenResponseMappers, raw []byte, tr *tokenResponse, serverURL string) error {
 	if tr.AccessToken != "" || mappers == nil {
 		return nil
 	}
-	mapper, ok := mappers[serverURL]
-	if !ok || mapper == nil {
+	mapper := mappers.lookup(serverURL)
+	if mapper == nil {
 		return nil
 	}
 	mapped, err := mapper(raw)
@@ -95,7 +83,24 @@ func applyTokenResponseMapper(mappers tokenResponseMappers, raw []byte, tr *toke
 			"oauth: token response mapper failed for %s: %s", serverURL, err)
 	}
 	if mapped != nil {
-		*tr = tokenResponseFromPublic(mapped)
+		if mapped.AccessToken != "" {
+			tr.AccessToken = mapped.AccessToken
+		}
+		if mapped.TokenType != "" {
+			tr.TokenType = mapped.TokenType
+		}
+		if mapped.ExpiresIn != 0 {
+			tr.ExpiresIn = mapped.ExpiresIn
+		}
+		if mapped.RefreshToken != "" {
+			tr.RefreshToken = mapped.RefreshToken
+		}
+		if mapped.Scope != "" {
+			tr.Scope = mapped.Scope
+		}
+		if mapped.IDToken != "" {
+			tr.IDToken = mapped.IDToken
+		}
 	}
 	return nil
 }
@@ -217,7 +222,7 @@ func authorizationURL(ctx context.Context, servers serverCache, clients clientSt
 // pendingStore/serverCache/tokenWriter/clientStore/httpDoFunc interfaces so it is
 // unit-testable with fakes. The clientStore lets the exchange attach confidential
 // client authentication (client_secret_post) when the initiating client is one.
-func handleCallback(ctx context.Context, do httpDoFunc, servers serverCache, pending pendingStore, tokens tokenWriter, clients clientStore, state, code string, mappers tokenResponseMappers) (*TokenEntry, error) {
+func handleCallback(ctx context.Context, do httpDoFunc, servers serverCache, pending pendingStore, tokens tokenWriter, clients clientStore, state, code string, mappers *TokenResponseMappers) (*TokenEntry, error) {
 	if strings.TrimSpace(state) == "" {
 		return nil, errors.Wrap(errors.InvalidArgument, "oauth: callback state must not be empty")
 	}

--- a/oauth/authorization.go
+++ b/oauth/authorization.go
@@ -59,10 +59,9 @@ type tokenResponse struct {
 	IDToken      string `json:"id_token"`
 }
 
-// tokenResponseMapperFunc is the function signature for the optional
-// TokenResponseMapper callback. It is defined here for readability in the
-// internal function signatures.
-type tokenResponseMapperFunc func(raw []byte) (*TokenResponse, error)
+// tokenResponseMappers is the type for the optional per-server-URL mapper map.
+// It is defined here for readability in the internal function signatures.
+type tokenResponseMappers map[string]func(raw []byte) (*TokenResponse, error)
 
 // tokenResponseFromPublic converts a public TokenResponse (returned by a
 // consumer-supplied TokenResponseMapper) into the internal tokenResponse used
@@ -78,11 +77,16 @@ func tokenResponseFromPublic(pub *TokenResponse) tokenResponse {
 	}
 }
 
-// applyTokenResponseMapper calls the consumer-supplied mapper when the standard
-// token-endpoint parse yielded an empty AccessToken. It is the shared mapper
-// application logic used by both handleCallback and refreshTokenExchange.
-func applyTokenResponseMapper(mapper tokenResponseMapperFunc, raw []byte, tr *tokenResponse, serverURL string) error {
-	if tr.AccessToken != "" || mapper == nil {
+// applyTokenResponseMapper looks up the consumer-supplied mapper for the given
+// serverURL and calls it when the standard token-endpoint parse yielded an empty
+// AccessToken. It is the shared mapper application logic used by both
+// handleCallback and refreshTokenExchange.
+func applyTokenResponseMapper(mappers tokenResponseMappers, raw []byte, tr *tokenResponse, serverURL string) error {
+	if tr.AccessToken != "" || mappers == nil {
+		return nil
+	}
+	mapper, ok := mappers[serverURL]
+	if !ok || mapper == nil {
 		return nil
 	}
 	mapped, err := mapper(raw)
@@ -124,7 +128,7 @@ func (m *OAuthManager) AuthorizationURL(ctx context.Context, opts AuthorizeOptio
 // authenticated session before calling this, and reject a mismatch, to prevent
 // login-CSRF / session-fixation.
 func (m *OAuthManager) HandleCallback(ctx context.Context, state string, code string) (*TokenEntry, error) {
-	return handleCallback(ctx, m.httpDo, m.serverTable, m.pendingTable, m.tokenTable, m.clientTable, state, code, m.config.TokenResponseMapper)
+	return handleCallback(ctx, m.httpDo, m.serverTable, m.pendingTable, m.tokenTable, m.clientTable, state, code, m.config.TokenResponseMappers)
 }
 
 // authorizationURL implements AuthorizationURL against the
@@ -213,7 +217,7 @@ func authorizationURL(ctx context.Context, servers serverCache, clients clientSt
 // pendingStore/serverCache/tokenWriter/clientStore/httpDoFunc interfaces so it is
 // unit-testable with fakes. The clientStore lets the exchange attach confidential
 // client authentication (client_secret_post) when the initiating client is one.
-func handleCallback(ctx context.Context, do httpDoFunc, servers serverCache, pending pendingStore, tokens tokenWriter, clients clientStore, state, code string, mapper tokenResponseMapperFunc) (*TokenEntry, error) {
+func handleCallback(ctx context.Context, do httpDoFunc, servers serverCache, pending pendingStore, tokens tokenWriter, clients clientStore, state, code string, mappers tokenResponseMappers) (*TokenEntry, error) {
 	if strings.TrimSpace(state) == "" {
 		return nil, errors.Wrap(errors.InvalidArgument, "oauth: callback state must not be empty")
 	}
@@ -293,7 +297,7 @@ func handleCallback(ctx context.Context, do httpDoFunc, servers serverCache, pen
 		return nil, errors.Wrapf(errors.GetErrCode(err),
 			"oauth: authorization code exchange failed for %s: %s", ps.ServerURL, err)
 	}
-	if err := applyTokenResponseMapper(mapper, raw, &tr, ps.ServerURL); err != nil {
+	if err := applyTokenResponseMapper(mappers, raw, &tr, ps.ServerURL); err != nil {
 		return nil, err
 	}
 	if tr.AccessToken == "" {

--- a/oauth/authorization_test.go
+++ b/oauth/authorization_test.go
@@ -315,7 +315,7 @@ func TestHandleCallback_SuccessfulExchange(t *testing.T) {
 		return jsonResponse(tokenResp), nil
 	}
 
-	entry, err := handleCallback(context.Background(), do, servers, pending, tokens, newFakeClientStore(), "state-1", "auth-code-1")
+	entry, err := handleCallback(context.Background(), do, servers, pending, tokens, newFakeClientStore(), "state-1", "auth-code-1", nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -390,7 +390,7 @@ func TestHandleCallback_UnknownState(t *testing.T) {
 		return nil, nil
 	}
 
-	_, err := handleCallback(context.Background(), do, servers, pending, tokens, newFakeClientStore(), "missing", "code")
+	_, err := handleCallback(context.Background(), do, servers, pending, tokens, newFakeClientStore(), "missing", "code", nil)
 	if err == nil {
 		t.Fatal("expected error for unknown/expired state")
 	}
@@ -412,10 +412,10 @@ func TestHandleCallback_EmptyStateOrCode(t *testing.T) {
 	}
 
 	clients := newFakeClientStore()
-	if _, err := handleCallback(context.Background(), do, servers, pending, tokens, clients, "", "code"); !errors.IsInvalidArgument(err) {
+	if _, err := handleCallback(context.Background(), do, servers, pending, tokens, clients, "", "code", nil); !errors.IsInvalidArgument(err) {
 		t.Errorf("empty state: expected InvalidArgument, got %v", err)
 	}
-	if _, err := handleCallback(context.Background(), do, servers, pending, tokens, clients, "state", ""); !errors.IsInvalidArgument(err) {
+	if _, err := handleCallback(context.Background(), do, servers, pending, tokens, clients, "state", "", nil); !errors.IsInvalidArgument(err) {
 		t.Errorf("empty code: expected InvalidArgument, got %v", err)
 	}
 }
@@ -439,7 +439,7 @@ func TestHandleCallback_ExchangeFailureKeepsPending(t *testing.T) {
 		return statusResponse(http.StatusBadRequest), nil
 	}
 
-	_, err := handleCallback(context.Background(), do, servers, pending, tokens, newFakeClientStore(), "state-1", "auth-code-1")
+	_, err := handleCallback(context.Background(), do, servers, pending, tokens, newFakeClientStore(), "state-1", "auth-code-1", nil)
 	if err == nil {
 		t.Fatal("expected error when token exchange fails")
 	}
@@ -472,7 +472,7 @@ func TestHandleCallback_NoAccessToken(t *testing.T) {
 		return jsonResponse(`{"token_type":"Bearer","expires_in":3600}`), nil
 	}
 
-	_, err := handleCallback(context.Background(), do, servers, pending, tokens, newFakeClientStore(), "state-1", "auth-code-1")
+	_, err := handleCallback(context.Background(), do, servers, pending, tokens, newFakeClientStore(), "state-1", "auth-code-1", nil)
 	if err == nil {
 		t.Fatal("expected error when response has no access_token")
 	}
@@ -505,7 +505,7 @@ func TestHandleCallback_ExpiredPendingState(t *testing.T) {
 		return nil, nil
 	}
 
-	_, err := handleCallback(context.Background(), do, servers, pending, tokens, newFakeClientStore(), "state-1", "auth-code-1")
+	_, err := handleCallback(context.Background(), do, servers, pending, tokens, newFakeClientStore(), "state-1", "auth-code-1", nil)
 	if !errors.IsNotFound(err) {
 		t.Fatalf("expected NotFound for expired state, got %v", err)
 	}
@@ -572,7 +572,7 @@ func TestHandleCallback_ClientRefRoundTrip(t *testing.T) {
 	}
 
 	do := func(_ *http.Request) (*http.Response, error) { return jsonResponse(tokenResp), nil }
-	entry, err := handleCallback(context.Background(), do, servers, pending, tokens, clients, params.State, "auth-code-1")
+	entry, err := handleCallback(context.Background(), do, servers, pending, tokens, clients, params.State, "auth-code-1", nil)
 	if err != nil {
 		t.Fatalf("callback: %v", err)
 	}
@@ -619,7 +619,7 @@ func TestHandleCallback_ConfidentialSendsSecret(t *testing.T) {
 		return jsonResponse(tokenResp), nil
 	}
 
-	if _, err := handleCallback(context.Background(), do, servers, pending, tokens, clients, "state-1", "auth-code-1"); err != nil {
+	if _, err := handleCallback(context.Background(), do, servers, pending, tokens, clients, "state-1", "auth-code-1", nil); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	if sentForm.Get("client_id") != "client-tenant-a" {
@@ -656,7 +656,7 @@ func TestHandleCallback_PublicNoSecret(t *testing.T) {
 		return jsonResponse(tokenResp), nil
 	}
 
-	if _, err := handleCallback(context.Background(), do, servers, pending, tokens, clients, "state-1", "auth-code-1"); err != nil {
+	if _, err := handleCallback(context.Background(), do, servers, pending, tokens, clients, "state-1", "auth-code-1", nil); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	if sentForm.Get("client_id") != "client-tenant-a" {
@@ -698,7 +698,7 @@ func TestHandleCallback_ClientIDMismatchFallsBack(t *testing.T) {
 		return jsonResponse(tokenResp), nil
 	}
 
-	if _, err := handleCallback(context.Background(), do, servers, pending, tokens, clients, "state-1", "auth-code-1"); err != nil {
+	if _, err := handleCallback(context.Background(), do, servers, pending, tokens, clients, "state-1", "auth-code-1", nil); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	if sentForm.Get("client_id") != "client-OLD" {

--- a/oauth/manager_e2e_test.go
+++ b/oauth/manager_e2e_test.go
@@ -141,7 +141,7 @@ func TestEndToEndFlow(t *testing.T) {
 		return discoverServer(ctx, do, servers, serverURL)
 	}
 	refresh := func(ctx context.Context, key *TokenKey, entry *TokenEntry) (*TokenEntry, error) {
-		return refreshTokenExchange(ctx, do, servers, clients, key, entry)
+		return refreshTokenExchange(ctx, do, servers, clients, key, entry, nil)
 	}
 	const accountID = "acct-1"
 
@@ -182,7 +182,7 @@ func TestEndToEndFlow(t *testing.T) {
 	}
 
 	// 4. Callback — exchange the code, persist the token, consume pending state.
-	token, err := handleCallback(ctx, do, servers, pending, tokens, clients, params.State, "auth-code-xyz")
+	token, err := handleCallback(ctx, do, servers, pending, tokens, clients, params.State, "auth-code-xyz", nil)
 	if err != nil {
 		t.Fatalf("callback: %v", err)
 	}

--- a/oauth/mapper_test.go
+++ b/oauth/mapper_test.go
@@ -1,0 +1,358 @@
+// Copyright © 2025-2026 Prabhjot Singh Sethi, All Rights reserved
+// Author: Prabhjot Singh Sethi <prabhjot.sethi@gmail.com>
+
+package oauth
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	coreerrors "github.com/go-core-stack/core/errors"
+)
+
+// --- TokenResponseMappers unit tests ---
+
+// Register with a trailing slash, lookup without (and reverse) must hit.
+func TestTokenResponseMappers_RegisterAndLookup(t *testing.T) {
+	m := NewTokenResponseMappers()
+	called := false
+	m.Register("https://slack.com/", func(raw []byte) (*TokenResponse, error) {
+		called = true
+		return &TokenResponse{AccessToken: "mapped"}, nil
+	})
+
+	// Lookup without trailing slash.
+	fn := m.lookup("https://slack.com")
+	if fn == nil {
+		t.Fatal("expected mapper for https://slack.com (registered with trailing slash)")
+	}
+	resp, err := fn(nil)
+	if err != nil || resp.AccessToken != "mapped" || !called {
+		t.Errorf("mapper not invoked correctly: resp=%+v err=%v called=%v", resp, err, called)
+	}
+
+	// Register without trailing slash, lookup with.
+	m2 := NewTokenResponseMappers()
+	m2.Register("https://example.com", func(raw []byte) (*TokenResponse, error) {
+		return &TokenResponse{AccessToken: "ex"}, nil
+	})
+	if fn2 := m2.lookup("https://example.com/"); fn2 == nil {
+		t.Fatal("expected mapper for https://example.com/ (registered without slash)")
+	}
+
+	// Miss for unregistered server.
+	if fn3 := m.lookup("https://other.com"); fn3 != nil {
+		t.Error("expected nil for unregistered server")
+	}
+}
+
+// Nil receiver on lookup returns nil; nil receiver on Register does not panic.
+func TestTokenResponseMappers_NilSafe(t *testing.T) {
+	var m *TokenResponseMappers
+	if fn := m.lookup("https://slack.com"); fn != nil {
+		t.Error("nil receiver lookup must return nil")
+	}
+	// Must not panic.
+	m.Register("https://slack.com", func(raw []byte) (*TokenResponse, error) {
+		return nil, nil
+	})
+}
+
+// --- handleCallback mapper tests ---
+
+// slackLikeResponse is a token-endpoint response where access_token is nested
+// inside an authed_user object (like Slack's V2 OAuth).
+const slackLikeResponse = `{
+	"ok": true,
+	"token_type": "Bearer",
+	"authed_user": {
+		"access_token": "xoxp-nested-token",
+		"token_type": "user"
+	}
+}`
+
+// slackMapper extracts the access_token from the authed_user object.
+func slackMapper(raw []byte) (*TokenResponse, error) {
+	var body struct {
+		AuthedUser struct {
+			AccessToken string `json:"access_token"`
+		} `json:"authed_user"`
+	}
+	if err := json.Unmarshal(raw, &body); err != nil {
+		return nil, err
+	}
+	return &TokenResponse{AccessToken: body.AuthedUser.AccessToken}, nil
+}
+
+func TestHandleCallback_TokenResponseMapper_Applied(t *testing.T) {
+	servers := newFakeServerCache()
+	servers.entries["https://api.example.com"] = authServer()
+	pending := newFakePendingStore()
+	seedPending(pending, "state-1", &PendingAuthState{
+		ServerURL:    "https://api.example.com",
+		AccountID:    "acct-1",
+		ClientID:     "client-abc",
+		CodeVerifier: "verifier-xyz",
+		RedirectURI:  "https://app.example.com/callback",
+		Scopes:       []string{"read"},
+	})
+	tokens := newFakeTokenWriter()
+
+	do := func(_ *http.Request) (*http.Response, error) {
+		return jsonResponse(slackLikeResponse), nil
+	}
+
+	mappers := NewTokenResponseMappers()
+	mappers.Register("https://api.example.com", slackMapper)
+
+	entry, err := handleCallback(context.Background(), do, servers, pending, tokens, newFakeClientStore(), "state-1", "auth-code-1", mappers)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if entry.AccessToken != "xoxp-nested-token" {
+		t.Errorf("AccessToken = %q, want xoxp-nested-token", entry.AccessToken)
+	}
+	if entry.TokenType != "Bearer" {
+		t.Errorf("TokenType = %q, want Bearer (preserved from standard parse)", entry.TokenType)
+	}
+}
+
+func TestHandleCallback_TokenResponseMapper_NotInvokedWhenAccessTokenPresent(t *testing.T) {
+	servers := newFakeServerCache()
+	servers.entries["https://api.example.com"] = authServer()
+	pending := newFakePendingStore()
+	seedPending(pending, "state-1", &PendingAuthState{
+		ServerURL:    "https://api.example.com",
+		AccountID:    "acct-1",
+		ClientID:     "client-abc",
+		CodeVerifier: "verifier-xyz",
+		RedirectURI:  "https://app.example.com/callback",
+	})
+	tokens := newFakeTokenWriter()
+
+	// Standard response with a top-level access_token.
+	do := func(_ *http.Request) (*http.Response, error) {
+		return jsonResponse(tokenResp), nil
+	}
+
+	mapperCalled := false
+	mappers := NewTokenResponseMappers()
+	mappers.Register("https://api.example.com", func(raw []byte) (*TokenResponse, error) {
+		mapperCalled = true
+		return &TokenResponse{AccessToken: "should-not-be-used"}, nil
+	})
+
+	entry, err := handleCallback(context.Background(), do, servers, pending, tokens, newFakeClientStore(), "state-1", "auth-code-1", mappers)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if mapperCalled {
+		t.Error("mapper must not be invoked when standard response has access_token")
+	}
+	if entry.AccessToken != "at-123" {
+		t.Errorf("AccessToken = %q, want at-123 from standard parse", entry.AccessToken)
+	}
+}
+
+func TestHandleCallback_TokenResponseMapper_LookupMiss(t *testing.T) {
+	servers := newFakeServerCache()
+	servers.entries["https://api.example.com"] = authServer()
+	pending := newFakePendingStore()
+	seedPending(pending, "state-1", &PendingAuthState{
+		ServerURL:    "https://api.example.com",
+		AccountID:    "acct-1",
+		ClientID:     "client-abc",
+		CodeVerifier: "verifier-xyz",
+		RedirectURI:  "https://app.example.com/callback",
+	})
+	tokens := newFakeTokenWriter()
+
+	// Response with no top-level access_token.
+	do := func(_ *http.Request) (*http.Response, error) {
+		return jsonResponse(`{"token_type":"Bearer","expires_in":3600}`), nil
+	}
+
+	// Mapper registered for a DIFFERENT server URL.
+	mappers := NewTokenResponseMappers()
+	mappers.Register("https://other.example.com", slackMapper)
+
+	_, err := handleCallback(context.Background(), do, servers, pending, tokens, newFakeClientStore(), "state-1", "auth-code-1", mappers)
+	if err == nil {
+		t.Fatal("expected error for missing access_token with no mapper match")
+	}
+	if !coreerrors.IsInvalidArgument(err) {
+		t.Errorf("expected InvalidArgument, got %v", err)
+	}
+	if !strings.Contains(err.Error(), "access_token") {
+		t.Errorf("error should mention access_token: %v", err)
+	}
+}
+
+func TestHandleCallback_TokenResponseMapper_ReturnsError(t *testing.T) {
+	servers := newFakeServerCache()
+	servers.entries["https://api.example.com"] = authServer()
+	pending := newFakePendingStore()
+	seedPending(pending, "state-1", &PendingAuthState{
+		ServerURL:    "https://api.example.com",
+		AccountID:    "acct-1",
+		ClientID:     "client-abc",
+		CodeVerifier: "verifier-xyz",
+		RedirectURI:  "https://app.example.com/callback",
+	})
+	tokens := newFakeTokenWriter()
+
+	do := func(_ *http.Request) (*http.Response, error) {
+		return jsonResponse(`{"ok":false,"error":"invalid_auth"}`), nil
+	}
+
+	mappers := NewTokenResponseMappers()
+	mappers.Register("https://api.example.com", func(raw []byte) (*TokenResponse, error) {
+		return nil, errors.New("slack says invalid_auth")
+	})
+
+	_, err := handleCallback(context.Background(), do, servers, pending, tokens, newFakeClientStore(), "state-1", "auth-code-1", mappers)
+	if err == nil {
+		t.Fatal("expected error from mapper")
+	}
+	if !coreerrors.IsInvalidArgument(err) {
+		t.Errorf("expected InvalidArgument, got %v", err)
+	}
+	if !strings.Contains(err.Error(), "api.example.com") {
+		t.Errorf("error should include server URL: %v", err)
+	}
+	if tokens.locates != 0 {
+		t.Errorf("must not persist a token on mapper error; locates=%d", tokens.locates)
+	}
+}
+
+// The mapper only sets AccessToken; token_type, expires_in, and scope from the
+// standard parse must be preserved (field-by-field merge).
+func TestHandleCallback_TokenResponseMapper_FieldByFieldMerge(t *testing.T) {
+	servers := newFakeServerCache()
+	servers.entries["https://api.example.com"] = authServer()
+	pending := newFakePendingStore()
+	seedPending(pending, "state-1", &PendingAuthState{
+		ServerURL:    "https://api.example.com",
+		AccountID:    "acct-1",
+		ClientID:     "client-abc",
+		CodeVerifier: "verifier-xyz",
+		RedirectURI:  "https://app.example.com/callback",
+		Scopes:       []string{"read", "write"},
+	})
+	tokens := newFakeTokenWriter()
+
+	// Server returns some fields top-level, but access_token is nested.
+	do := func(_ *http.Request) (*http.Response, error) {
+		return jsonResponse(`{"token_type":"Bearer","expires_in":7200,"scope":"read write","authed_user":{"access_token":"xoxp-merged"}}`), nil
+	}
+
+	// Mapper only extracts access_token.
+	mappers := NewTokenResponseMappers()
+	mappers.Register("https://api.example.com", func(raw []byte) (*TokenResponse, error) {
+		var body struct {
+			AuthedUser struct {
+				AccessToken string `json:"access_token"`
+			} `json:"authed_user"`
+		}
+		if err := json.Unmarshal(raw, &body); err != nil {
+			return nil, err
+		}
+		return &TokenResponse{AccessToken: body.AuthedUser.AccessToken}, nil
+	})
+
+	entry, err := handleCallback(context.Background(), do, servers, pending, tokens, newFakeClientStore(), "state-1", "auth-code-1", mappers)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if entry.AccessToken != "xoxp-merged" {
+		t.Errorf("AccessToken = %q, want xoxp-merged", entry.AccessToken)
+	}
+	// These must come from the standard JSON parse, not the mapper.
+	if entry.TokenType != "Bearer" {
+		t.Errorf("TokenType = %q, want Bearer (from standard parse)", entry.TokenType)
+	}
+	if entry.ExpiresAt == 0 {
+		t.Error("ExpiresAt must be set from standard parse expires_in=7200")
+	}
+	if strings.Join(entry.Scopes, " ") != "read write" {
+		t.Errorf("Scopes = %v, want [read write] (from standard parse)", entry.Scopes)
+	}
+}
+
+// --- refreshTokenExchange mapper tests ---
+
+func TestRefreshTokenExchange_TokenResponseMapper_Applied(t *testing.T) {
+	servers := newFakeServerCache()
+	servers.entries["https://api.example.com"] = revServer()
+	clients := newFakeClientStore()
+	clients.entries["https://api.example.com"] = &ClientEntry{ClientID: "client-abc"}
+
+	do := func(_ *http.Request) (*http.Response, error) {
+		return jsonResponse(slackLikeResponse), nil
+	}
+
+	mappers := NewTokenResponseMappers()
+	mappers.Register("https://api.example.com", slackMapper)
+
+	prev := &TokenEntry{AccessToken: "old", RefreshToken: "rt-old", State: SessionActive}
+	got, err := refreshTokenExchange(context.Background(), do, servers, clients, testTokenKey(), prev, mappers)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got.AccessToken != "xoxp-nested-token" {
+		t.Errorf("AccessToken = %q, want xoxp-nested-token", got.AccessToken)
+	}
+	if got.TokenType != "Bearer" {
+		t.Errorf("TokenType = %q, want Bearer (preserved from standard parse)", got.TokenType)
+	}
+}
+
+func TestRefreshTokenExchange_TokenResponseMapper_ErrorIsPermanent(t *testing.T) {
+	servers := newFakeServerCache()
+	servers.entries["https://api.example.com"] = revServer()
+	clients := newFakeClientStore()
+	clients.entries["https://api.example.com"] = &ClientEntry{ClientID: "client-abc"}
+
+	// Return a response with no top-level access_token so the mapper fires.
+	do := func(_ *http.Request) (*http.Response, error) {
+		return jsonResponse(`{"ok":false,"error":"invalid_auth"}`), nil
+	}
+
+	mappers := NewTokenResponseMappers()
+	mappers.Register("https://api.example.com", func(raw []byte) (*TokenResponse, error) {
+		return nil, errors.New("mapper failed")
+	})
+
+	prev := &TokenEntry{AccessToken: "old", RefreshToken: "rt-old", State: SessionActive}
+	_, err := refreshTokenExchange(context.Background(), do, servers, clients, testTokenKey(), prev, mappers)
+	if err == nil {
+		t.Fatal("expected error from mapper on refresh path")
+	}
+	if !errors.Is(err, errPermanentRefresh) {
+		t.Errorf("mapper error on refresh must be permanent, got %v", err)
+	}
+}
+
+// jsonResponse is a test helper that builds a 200 OK HTTP response with the
+// given JSON body. It is defined in authorization_test.go for the callback
+// tests; this is a compile guard that the helper exists in this package.
+var _ = jsonResponse
+
+// statusResponse is a test helper that builds a non-JSON HTTP response with the
+// given status code. Defined in the shared test helpers.
+var _ = statusResponse
+
+// Helper to build a simple JSON response for tests — mirrors the one in
+// authorization_test.go but avoids redeclaration by referencing the shared one.
+func mapperTestJSONResponse(body string) *http.Response {
+	return &http.Response{
+		StatusCode: http.StatusOK,
+		Body:       io.NopCloser(strings.NewReader(body)),
+		Header:     http.Header{"Content-Type": []string{"application/json"}},
+	}
+}

--- a/oauth/token.go
+++ b/oauth/token.go
@@ -133,7 +133,7 @@ func (m *OAuthManager) ListTokens(ctx context.Context, serverURL string, clientR
 // error classification is identical everywhere, and each owns the surrounding
 // lock and persistence. It is wired into the reconciler by NewOAuthManager.
 func (m *OAuthManager) refreshToken(ctx context.Context, key *TokenKey, entry *TokenEntry) (*TokenEntry, error) {
-	return refreshTokenExchange(ctx, m.httpDo, m.serverTable, m.clientTable, key, entry, m.config.TokenResponseMapper)
+	return refreshTokenExchange(ctx, m.httpDo, m.serverTable, m.clientTable, key, entry, m.config.TokenResponseMappers)
 }
 
 // getToken implements GetToken against the tokenStore/refreshLockerAPI/refreshFunc
@@ -265,7 +265,7 @@ func lockedRefresh(ctx context.Context, tokens tokenStore, locks refreshLockerAP
 // client and builds the refreshed TokenEntry. A missing refresh token, or an
 // invalid_grant / invalid_client response, is a permanent failure
 // (errPermanentRefresh); other failures are transient.
-func refreshTokenExchange(ctx context.Context, do httpDoFunc, servers serverCache, clients clientStore, key *TokenKey, entry *TokenEntry, mapper tokenResponseMapperFunc) (*TokenEntry, error) {
+func refreshTokenExchange(ctx context.Context, do httpDoFunc, servers serverCache, clients clientStore, key *TokenKey, entry *TokenEntry, mappers tokenResponseMappers) (*TokenEntry, error) {
 	if entry.RefreshPolicy == RefreshPolicyNoRefresh {
 		// The server issued a non-refreshable token (e.g. an offline token with
 		// no expiry). There is nothing to refresh — a normal terminal state, not
@@ -312,7 +312,7 @@ func refreshTokenExchange(ctx context.Context, do httpDoFunc, servers serverCach
 	if err != nil {
 		return nil, err
 	}
-	if err := applyTokenResponseMapper(mapper, raw, tr, key.ServerURL); err != nil {
+	if err := applyTokenResponseMapper(mappers, raw, tr, key.ServerURL); err != nil {
 		return nil, err
 	}
 	if tr.AccessToken == "" {

--- a/oauth/token.go
+++ b/oauth/token.go
@@ -265,7 +265,7 @@ func lockedRefresh(ctx context.Context, tokens tokenStore, locks refreshLockerAP
 // client and builds the refreshed TokenEntry. A missing refresh token, or an
 // invalid_grant / invalid_client response, is a permanent failure
 // (errPermanentRefresh); other failures are transient.
-func refreshTokenExchange(ctx context.Context, do httpDoFunc, servers serverCache, clients clientStore, key *TokenKey, entry *TokenEntry, mappers tokenResponseMappers) (*TokenEntry, error) {
+func refreshTokenExchange(ctx context.Context, do httpDoFunc, servers serverCache, clients clientStore, key *TokenKey, entry *TokenEntry, mappers *TokenResponseMappers) (*TokenEntry, error) {
 	if entry.RefreshPolicy == RefreshPolicyNoRefresh {
 		// The server issued a non-refreshable token (e.g. an offline token with
 		// no expiry). There is nothing to refresh — a normal terminal state, not
@@ -313,7 +313,11 @@ func refreshTokenExchange(ctx context.Context, do httpDoFunc, servers serverCach
 		return nil, err
 	}
 	if err := applyTokenResponseMapper(mappers, raw, tr, key.ServerURL); err != nil {
-		return nil, err
+		// A mapper failure is a programmer error in the consumer-supplied
+		// function — it is not transient and will not fix itself. Classify it
+		// as permanent so the reconciler revokes the session instead of
+		// retrying on every refresh cycle.
+		return nil, fmt.Errorf("%s: %w", err, errPermanentRefresh)
 	}
 	if tr.AccessToken == "" {
 		return nil, errors.Wrapf(errors.InvalidArgument,

--- a/oauth/token.go
+++ b/oauth/token.go
@@ -133,7 +133,7 @@ func (m *OAuthManager) ListTokens(ctx context.Context, serverURL string, clientR
 // error classification is identical everywhere, and each owns the surrounding
 // lock and persistence. It is wired into the reconciler by NewOAuthManager.
 func (m *OAuthManager) refreshToken(ctx context.Context, key *TokenKey, entry *TokenEntry) (*TokenEntry, error) {
-	return refreshTokenExchange(ctx, m.httpDo, m.serverTable, m.clientTable, key, entry)
+	return refreshTokenExchange(ctx, m.httpDo, m.serverTable, m.clientTable, key, entry, m.config.TokenResponseMapper)
 }
 
 // getToken implements GetToken against the tokenStore/refreshLockerAPI/refreshFunc
@@ -265,7 +265,7 @@ func lockedRefresh(ctx context.Context, tokens tokenStore, locks refreshLockerAP
 // client and builds the refreshed TokenEntry. A missing refresh token, or an
 // invalid_grant / invalid_client response, is a permanent failure
 // (errPermanentRefresh); other failures are transient.
-func refreshTokenExchange(ctx context.Context, do httpDoFunc, servers serverCache, clients clientStore, key *TokenKey, entry *TokenEntry) (*TokenEntry, error) {
+func refreshTokenExchange(ctx context.Context, do httpDoFunc, servers serverCache, clients clientStore, key *TokenKey, entry *TokenEntry, mapper tokenResponseMapperFunc) (*TokenEntry, error) {
 	if entry.RefreshPolicy == RefreshPolicyNoRefresh {
 		// The server issued a non-refreshable token (e.g. an offline token with
 		// no expiry). There is nothing to refresh — a normal terminal state, not
@@ -308,8 +308,11 @@ func refreshTokenExchange(ctx context.Context, do httpDoFunc, servers serverCach
 	// that reject an explicit scope on refresh. The granted scope is preserved
 	// from the response (or the prior entry) in refreshedTokenEntry.
 
-	tr, err := postTokenEndpoint(ctx, do, server.TokenEndpoint, form)
+	tr, raw, err := postTokenEndpoint(ctx, do, server.TokenEndpoint, form)
 	if err != nil {
+		return nil, err
+	}
+	if err := applyTokenResponseMapper(mapper, raw, tr, key.ServerURL); err != nil {
 		return nil, err
 	}
 	if tr.AccessToken == "" {
@@ -525,18 +528,20 @@ func (k *TokenKey) id() string {
 // the JSON token response. On a non-2xx response it parses the RFC 6749 §5.2
 // error body and classifies invalid_grant / invalid_client as permanent
 // (errPermanentRefresh); every other failure is returned as a transient error.
-// The response body is bounded by maxMetadataBytes.
-func postTokenEndpoint(ctx context.Context, do httpDoFunc, endpoint string, form url.Values) (*tokenResponse, error) {
+// The response body is bounded by maxMetadataBytes. The raw response bytes are
+// returned alongside the parsed response so callers can apply a
+// TokenResponseMapper when the standard parse yields an empty access_token.
+func postTokenEndpoint(ctx context.Context, do httpDoFunc, endpoint string, form url.Values) (*tokenResponse, []byte, error) {
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint, strings.NewReader(form.Encode()))
 	if err != nil {
-		return nil, errors.Wrapf(errors.InvalidArgument, "oauth: failed to build request for %s: %s", endpoint, err)
+		return nil, nil, errors.Wrapf(errors.InvalidArgument, "oauth: failed to build request for %s: %s", endpoint, err)
 	}
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 	req.Header.Set("Accept", "application/json")
 
 	resp, err := do(req)
 	if err != nil {
-		return nil, errors.Wrapf(errors.Unknown, "oauth: request to %s failed: %s", endpoint, err)
+		return nil, nil, errors.Wrapf(errors.Unknown, "oauth: request to %s failed: %s", endpoint, err)
 	}
 	limited := io.LimitReader(resp.Body, maxMetadataBytes)
 	defer func() {
@@ -546,18 +551,18 @@ func postTokenEndpoint(ctx context.Context, do httpDoFunc, endpoint string, form
 
 	raw, err := io.ReadAll(limited)
 	if err != nil {
-		return nil, errors.Wrapf(errors.Unknown, "oauth: failed to read response from %s: %s", endpoint, err)
+		return nil, nil, errors.Wrapf(errors.Unknown, "oauth: failed to read response from %s: %s", endpoint, err)
 	}
 
 	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
-		return nil, classifyTokenError(endpoint, resp.StatusCode, raw)
+		return nil, nil, classifyTokenError(endpoint, resp.StatusCode, raw)
 	}
 
 	var tr tokenResponse
 	if err := json.Unmarshal(raw, &tr); err != nil {
-		return nil, errors.Wrapf(errors.InvalidArgument, "oauth: failed to parse token response from %s: %s", endpoint, err)
+		return nil, nil, errors.Wrapf(errors.InvalidArgument, "oauth: failed to parse token response from %s: %s", endpoint, err)
 	}
-	return &tr, nil
+	return &tr, raw, nil
 }
 
 // classifyTokenError turns a non-2xx token-endpoint response into a permanent

--- a/oauth/token_test.go
+++ b/oauth/token_test.go
@@ -472,7 +472,7 @@ func TestRefreshTokenExchange_Success(t *testing.T) {
 	}
 
 	prev := &TokenEntry{AccessToken: "old", RefreshToken: "rt-old", Scopes: []string{"read", "write"}, State: SessionFailed}
-	got, err := refreshTokenExchange(context.Background(), do, servers, clients, testTokenKey(), prev)
+	got, err := refreshTokenExchange(context.Background(), do, servers, clients, testTokenKey(), prev, nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -577,7 +577,7 @@ func TestRefreshTokenExchange_ConfidentialSendsSecret(t *testing.T) {
 	}
 
 	prev := &TokenEntry{AccessToken: "old", RefreshToken: "rt-old", State: SessionActive}
-	if _, err := refreshTokenExchange(context.Background(), do, servers, clients, testTokenKey(), prev); err != nil {
+	if _, err := refreshTokenExchange(context.Background(), do, servers, clients, testTokenKey(), prev, nil); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	if sentForm.Get("client_id") != "client-abc" {
@@ -603,7 +603,7 @@ func TestRefreshTokenExchange_PublicNoSecret(t *testing.T) {
 	}
 
 	prev := &TokenEntry{AccessToken: "old", RefreshToken: "rt-old", State: SessionActive}
-	if _, err := refreshTokenExchange(context.Background(), do, servers, clients, testTokenKey(), prev); err != nil {
+	if _, err := refreshTokenExchange(context.Background(), do, servers, clients, testTokenKey(), prev, nil); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	if sentForm.Get("client_id") != "client-abc" {
@@ -625,7 +625,7 @@ func TestRefreshTokenExchange_KeepsPriorRefreshToken(t *testing.T) {
 		return jsonResponse(`{"access_token":"at-new","token_type":"Bearer","expires_in":3600}`), nil
 	}
 	prev := &TokenEntry{AccessToken: "old", RefreshToken: "rt-keep", State: SessionActive}
-	got, err := refreshTokenExchange(context.Background(), do, servers, clients, testTokenKey(), prev)
+	got, err := refreshTokenExchange(context.Background(), do, servers, clients, testTokenKey(), prev, nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -651,7 +651,7 @@ func TestRefreshTokenExchange_MissingExpiresInResetsExpiry(t *testing.T) {
 	stalePast := time.Now().Add(-time.Hour).Unix()
 	prev := &TokenEntry{AccessToken: "old", RefreshToken: "rt", State: SessionActive, ExpiresAt: stalePast}
 
-	got, err := refreshTokenExchange(context.Background(), do, servers, clients, testTokenKey(), prev)
+	got, err := refreshTokenExchange(context.Background(), do, servers, clients, testTokenKey(), prev, nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -671,7 +671,7 @@ func TestRefreshTokenExchange_NoRefreshTokenIsPermanent(t *testing.T) {
 		return nil, nil
 	}
 	prev := &TokenEntry{AccessToken: "old", State: SessionActive} // no RefreshToken
-	_, err := refreshTokenExchange(context.Background(), do, servers, clients, testTokenKey(), prev)
+	_, err := refreshTokenExchange(context.Background(), do, servers, clients, testTokenKey(), prev, nil)
 	if !errors.Is(err, errPermanentRefresh) {
 		t.Fatalf("a missing refresh token must be a permanent failure, got %v", err)
 	}
@@ -688,7 +688,7 @@ func TestRefreshTokenExchange_NoRefreshPolicyReturnsEntry(t *testing.T) {
 		return nil, nil
 	}
 	entry := &TokenEntry{AccessToken: "offline-at", RefreshPolicy: RefreshPolicyNoRefresh, State: SessionActive}
-	got, err := refreshTokenExchange(context.Background(), do, servers, clients, testTokenKey(), entry)
+	got, err := refreshTokenExchange(context.Background(), do, servers, clients, testTokenKey(), entry, nil)
 	if err != nil {
 		t.Fatalf("NoRefresh must not be an error, got %v", err)
 	}
@@ -708,7 +708,7 @@ func TestRefreshTokenExchange_RefreshableEmptyTokenIsPermanent(t *testing.T) {
 		return nil, nil
 	}
 	entry := &TokenEntry{AccessToken: "old", RefreshPolicy: RefreshPolicyRefreshable, State: SessionActive} // no RefreshToken
-	_, err := refreshTokenExchange(context.Background(), do, servers, clients, testTokenKey(), entry)
+	_, err := refreshTokenExchange(context.Background(), do, servers, clients, testTokenKey(), entry, nil)
 	if !errors.Is(err, errPermanentRefresh) {
 		t.Fatalf("Refreshable + empty token must be permanent, got %v", err)
 	}
@@ -766,7 +766,7 @@ func assertRefreshClassification(t *testing.T, status int, body string, wantPerm
 	do := func(_ *http.Request) (*http.Response, error) { return jsonStatusResponse(status, body), nil }
 
 	prev := &TokenEntry{RefreshToken: "rt", State: SessionActive}
-	_, err := refreshTokenExchange(context.Background(), do, servers, clients, testTokenKey(), prev)
+	_, err := refreshTokenExchange(context.Background(), do, servers, clients, testTokenKey(), prev, nil)
 	if err == nil {
 		t.Fatalf("expected an error for HTTP %d", status)
 	}

--- a/oauth/types.go
+++ b/oauth/types.go
@@ -210,9 +210,10 @@ type TokenRefreshLockKey struct {
 // --- options / params ---
 
 // TokenResponse is the public representation of an OAuth token-endpoint
-// response. It is the return type of TokenResponseMapper, allowing consumers
-// to normalize provider-specific JSON structures into the standard fields the
-// library expects. The fields mirror the RFC 6749 §5.1 access-token response.
+// response. It is the return type of a TokenResponseMappers entry, allowing
+// consumers to normalize provider-specific JSON structures into the standard
+// fields the library expects. The fields mirror the RFC 6749 §5.1
+// access-token response.
 type TokenResponse struct {
 	AccessToken  string `json:"access_token"`
 	TokenType    string `json:"token_type"`
@@ -231,15 +232,18 @@ type OAuthConfig struct {
 	EncryptorKey string       // optional, falls back to ENCRYPTOR_KEY env
 	HTTPClient   *http.Client // optional, defaults to 30s-timeout client
 
-	// TokenResponseMapper, when set, is called when a token-endpoint response
-	// does not contain a top-level access_token (per RFC 6749 §5.1). It
-	// receives the raw JSON response body and returns a normalized
-	// TokenResponse with AccessToken populated from wherever the provider
-	// nests it. This supports providers (e.g. Slack) whose token responses
-	// embed the access token inside a provider-specific object rather than at
-	// the top level. If not set, the library requires a top-level
-	// access_token and returns an error when it is absent.
-	TokenResponseMapper func(raw []byte) (*TokenResponse, error)
+	// TokenResponseMappers maps a normalized server URL to a mapper function
+	// that normalizes non-standard token-endpoint responses. When a
+	// token-endpoint response does not contain a top-level access_token (per
+	// RFC 6749 §5.1), the library looks up a mapper for the requesting server
+	// URL from this map. If found, it is called with the raw JSON response
+	// body and returns a normalized TokenResponse with AccessToken populated
+	// from wherever the provider nests it. This supports providers (e.g.
+	// Slack) whose token responses embed the access token inside a
+	// provider-specific object rather than at the top level. If no mapper is
+	// registered for the server (or the map is nil), the library requires a
+	// top-level access_token and returns an error when it is absent.
+	TokenResponseMappers map[string]func(raw []byte) (*TokenResponse, error)
 }
 
 // RegisterClientOptions parameterizes dynamic client registration.

--- a/oauth/types.go
+++ b/oauth/types.go
@@ -223,6 +223,44 @@ type TokenResponse struct {
 	IDToken      string `json:"id_token"`
 }
 
+// TokenResponseMappers holds per-server-URL mapper functions that normalize
+// non-standard token-endpoint responses. It owns URL normalization on both
+// Register and lookup so the consumer never needs to worry about trailing
+// slashes or whitespace in server URLs.
+//
+// The zero value is not usable; create instances with NewTokenResponseMappers.
+type TokenResponseMappers struct {
+	m map[string]func(raw []byte) (*TokenResponse, error)
+}
+
+// NewTokenResponseMappers returns an initialized TokenResponseMappers ready
+// for Register calls.
+func NewTokenResponseMappers() *TokenResponseMappers {
+	return &TokenResponseMappers{
+		m: make(map[string]func(raw []byte) (*TokenResponse, error)),
+	}
+}
+
+// Register associates a mapper function with a server URL. The URL is
+// normalized (trimmed, trailing-slash stripped) before storing so a lookup
+// with any variant of the same URL matches.
+func (t *TokenResponseMappers) Register(serverURL string, mapper func(raw []byte) (*TokenResponse, error)) {
+	if t == nil {
+		return
+	}
+	t.m[normalizeServerURL(serverURL)] = mapper
+}
+
+// lookup returns the mapper registered for the given server URL, or nil if
+// none is registered. The URL is normalized before lookup. A nil receiver is
+// safe and returns nil.
+func (t *TokenResponseMappers) lookup(serverURL string) func(raw []byte) (*TokenResponse, error) {
+	if t == nil || t.m == nil {
+		return nil
+	}
+	return t.m[normalizeServerURL(serverURL)]
+}
+
 // OAuthConfig configures an OAuthManager. Only RedirectURI is conceptually
 // required for flows; the remaining fields carry sensible defaults.
 type OAuthConfig struct {
@@ -232,18 +270,23 @@ type OAuthConfig struct {
 	EncryptorKey string       // optional, falls back to ENCRYPTOR_KEY env
 	HTTPClient   *http.Client // optional, defaults to 30s-timeout client
 
-	// TokenResponseMappers maps a normalized server URL to a mapper function
-	// that normalizes non-standard token-endpoint responses. When a
+	// TokenResponseMappers holds optional per-server-URL mapper functions
+	// that normalize non-standard token-endpoint responses. When a
 	// token-endpoint response does not contain a top-level access_token (per
 	// RFC 6749 §5.1), the library looks up a mapper for the requesting server
-	// URL from this map. If found, it is called with the raw JSON response
-	// body and returns a normalized TokenResponse with AccessToken populated
-	// from wherever the provider nests it. This supports providers (e.g.
-	// Slack) whose token responses embed the access token inside a
-	// provider-specific object rather than at the top level. If no mapper is
-	// registered for the server (or the map is nil), the library requires a
-	// top-level access_token and returns an error when it is absent.
-	TokenResponseMappers map[string]func(raw []byte) (*TokenResponse, error)
+	// URL. If found, it is called with the raw JSON response body; the
+	// returned TokenResponse fields are merged field-by-field into the
+	// standard parse (only non-zero fields from the mapper overwrite). This
+	// supports providers (e.g. Slack) whose token responses embed the access
+	// token inside a provider-specific object rather than at the top level.
+	// If no mapper is registered for the server (or the field is nil), the
+	// library requires a top-level access_token and returns an error when it
+	// is absent.
+	//
+	// Create with NewTokenResponseMappers and populate via Register before
+	// passing to NewOAuthManager. The value must not be mutated after
+	// NewOAuthManager returns.
+	TokenResponseMappers *TokenResponseMappers
 }
 
 // RegisterClientOptions parameterizes dynamic client registration.

--- a/oauth/types.go
+++ b/oauth/types.go
@@ -209,6 +209,19 @@ type TokenRefreshLockKey struct {
 
 // --- options / params ---
 
+// TokenResponse is the public representation of an OAuth token-endpoint
+// response. It is the return type of TokenResponseMapper, allowing consumers
+// to normalize provider-specific JSON structures into the standard fields the
+// library expects. The fields mirror the RFC 6749 §5.1 access-token response.
+type TokenResponse struct {
+	AccessToken  string `json:"access_token"`
+	TokenType    string `json:"token_type"`
+	ExpiresIn    int64  `json:"expires_in"`
+	RefreshToken string `json:"refresh_token"`
+	Scope        string `json:"scope"`
+	IDToken      string `json:"id_token"`
+}
+
 // OAuthConfig configures an OAuthManager. Only RedirectURI is conceptually
 // required for flows; the remaining fields carry sensible defaults.
 type OAuthConfig struct {
@@ -217,6 +230,16 @@ type OAuthConfig struct {
 	ClientName   string       // for dynamic registration metadata
 	EncryptorKey string       // optional, falls back to ENCRYPTOR_KEY env
 	HTTPClient   *http.Client // optional, defaults to 30s-timeout client
+
+	// TokenResponseMapper, when set, is called when a token-endpoint response
+	// does not contain a top-level access_token (per RFC 6749 §5.1). It
+	// receives the raw JSON response body and returns a normalized
+	// TokenResponse with AccessToken populated from wherever the provider
+	// nests it. This supports providers (e.g. Slack) whose token responses
+	// embed the access token inside a provider-specific object rather than at
+	// the top level. If not set, the library requires a top-level
+	// access_token and returns an error when it is absent.
+	TokenResponseMapper func(raw []byte) (*TokenResponse, error)
 }
 
 // RegisterClientOptions parameterizes dynamic client registration.


### PR DESCRIPTION
## Summary

Adds a per-server-URL `TokenResponseMappers` map to `OAuthConfig` so consumers can register provider-specific mapper functions that normalize non-standard OAuth token-endpoint responses (e.g. Slack's V2 user-token-only flow, which nests `access_token` inside `authed_user` instead of at the top level per RFC 6749 §5.1).

When the standard JSON parse yields an empty `access_token`, the library looks up a mapper for the requesting server URL and calls it with the raw response bytes, letting the consumer extract the token from wherever the provider nests it — without the library itself becoming provider-aware.

## Design — Option A (per-server mapper map)

The mapper is keyed by normalized server URL — the same key that threads through every table in the library (`ServerKey.ServerURL`, `ClientKey.ServerURL`, `TokenKey.ServerURL`, `PendingAuthState.ServerURL`). The library already has `serverURL` in scope at both call sites (`ps.ServerURL` in `handleCallback`, `key.ServerURL` in `refreshTokenExchange`), so the lookup is trivial.

Benefits over a single-function design:
- **No JSON sniffing** — mappers don't need to guess which provider's response format is in play
- **No consumer-side switch statements** — the library owns the dispatch via a simple map lookup
- **Declarative composition** — adding a new non-standard provider is just adding a map entry
- **Zero-cost for compliant providers** — when `AccessToken` is already populated from the standard parse, the map is never consulted

## Changes

- **`oauth/types.go`** — Added public `TokenResponse` struct (mirrors internal `tokenResponse`) and `TokenResponseMappers map[string]func(raw []byte) (*TokenResponse, error)` field on `OAuthConfig`.
- **`oauth/authorization.go`** — Added `tokenResponseMappers` type alias (map), `tokenResponseFromPublic()` converter, and shared `applyTokenResponseMapper()` helper with per-server lookup. Updated `postForm` to return raw bytes. Threaded mappers through `handleCallback` → `HandleCallback`.
- **`oauth/token.go`** — Updated `postTokenEndpoint` to return raw bytes. Threaded mappers through `refreshTokenExchange` → `OAuthManager.refreshToken`.
- **`oauth/authorization_test.go`** — Updated 12 `handleCallback` call sites (pass `nil` mappers).
- **`oauth/token_test.go`** — Updated 9 `refreshTokenExchange` call sites (pass `nil` mappers).
- **`oauth/manager_e2e_test.go`** — Updated 2 call sites (`handleCallback` + `refreshTokenExchange`).

## Consumer usage (OCM example for Slack)

```go
cfg := oauth.OAuthConfig{
    // ...
    TokenResponseMappers: map[string]func(raw []byte) (*oauth.TokenResponse, error){
        "https://slack.com": func(raw []byte) (*oauth.TokenResponse, error) {
            var envelope struct {
                AuthedUser struct {
                    AccessToken string `json:"access_token"`
                    TokenType   string `json:"token_type"`
                    Scope       string `json:"scope"`
                } `json:"authed_user"`
            }
            if err := json.Unmarshal(raw, &envelope); err != nil {
                return nil, err
            }
            if envelope.AuthedUser.AccessToken == "" {
                return nil, fmt.Errorf("authed_user.access_token missing")
            }
            return &oauth.TokenResponse{
                AccessToken: envelope.AuthedUser.AccessToken,
                TokenType:   envelope.AuthedUser.TokenType,
                Scope:       envelope.AuthedUser.Scope,
            }, nil
        },
    },
}
```

## Test plan

- [ ] All existing tests pass with `nil` mappers (no behavioural change for compliant providers)
- [ ] Verify compile: `go build ./oauth/...`
- [ ] Verify tests: `go test ./oauth/...`
- [ ] Integration: wire a Slack-specific mapper in OCM and confirm token exchange succeeds


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional token-response mapping support to OAuth configuration, enabling per-server URL mappers to normalize non-standard token endpoint responses into the standard token structure.
  * Token mapping is applied during both authorization callbacks and refresh token exchanges when a response lacks a top-level access token.
* **Bug Fixes**
  * Improved recovery from token responses with missing/empty access-token fields by merging mapped values into the parsed token data.
* **Tests**
  * Updated and expanded OAuth and end-to-end test coverage to reflect the new mapper behavior and mapper failure handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->