### PR TITLE
feat: add DisablePKCE option for providers that reject PKCE

### DIFF
--- a/oauth/authorization.go
+++ b/oauth/authorization.go
@@ -177,11 +177,23 @@ func authorizationURL(ctx context.Context, servers serverCache, clients clientSt
 			"oauth: server %s does not advertise an authorization endpoint", normalized)
 	}
 
-	// PKCE (S256) and CSRF state, both from crypto/rand.
-	verifier, err := generateRandomToken(codeVerifierBytes)
-	if err != nil {
-		return nil, errors.Wrapf(errors.GetErrCode(err), "oauth: failed to generate PKCE verifier: %s", err)
+	// PKCE (S256) — generate verifier and challenge unless the consumer has
+	// explicitly disabled PKCE (e.g., Meta System User tokens reject
+	// code_challenge). When disabled, both fields remain empty strings and
+	// the PendingAuthState stores an empty CodeVerifier, which handleCallback
+	// uses as the signal to omit code_verifier from the token exchange.
+	var verifier, challenge, challengeMethod string
+	if !opts.DisablePKCE {
+		var err error
+		verifier, err = generateRandomToken(codeVerifierBytes)
+		if err != nil {
+			return nil, errors.Wrapf(errors.GetErrCode(err), "oauth: failed to generate PKCE verifier: %s", err)
+		}
+		challenge = codeChallengeS256(verifier)
+		challengeMethod = CodeChallengeMethodS256
 	}
+
+	// CSRF state, always from crypto/rand (independent of PKCE).
 	state, err := generateRandomToken(stateBytes)
 	if err != nil {
 		return nil, errors.Wrapf(errors.GetErrCode(err), "oauth: failed to generate CSRF state: %s", err)
@@ -190,6 +202,8 @@ func authorizationURL(ctx context.Context, servers serverCache, clients clientSt
 	// Persist the transient state; the verifier is encrypted at rest by
 	// PendingAuthState.MarshalBSON. Everything needed to finish the exchange
 	// lives here, so the callback needs no in-memory session.
+	// When PKCE is disabled, CodeVerifier is stored as "" — handleCallback
+	// checks for this and omits code_verifier from the exchange form.
 	ps := &PendingAuthState{
 		ServerURL:    normalized,
 		ClientRef:    merged.ClientRef,
@@ -212,8 +226,8 @@ func authorizationURL(ctx context.Context, servers serverCache, clients clientSt
 		ResponseType:        responseTypeCode,
 		Scope:               strings.Join(merged.Scopes, " "),
 		State:               state,
-		CodeChallenge:       codeChallengeS256(verifier),
-		CodeChallengeMethod: CodeChallengeMethodS256,
+		CodeChallenge:       challenge,
+		CodeChallengeMethod: challengeMethod,
 		ExtraParams:         merged.ExtraParams,
 	}, nil
 }
@@ -260,16 +274,17 @@ func handleCallback(ctx context.Context, do httpDoFunc, servers serverCache, pen
 			"oauth: server %s has no usable token endpoint", ps.ServerURL)
 	}
 
-	// RFC 6749 §4.1.3 / RFC 7636 §4.5 authorization-code exchange, presenting the
-	// stored PKCE verifier. The client_id is the one that initiated the flow
-	// (persisted in the pending state), not whatever is currently registered: the
-	// authorization code is bound to the initiating client, so a re-registration
-	// between AuthorizationURL and HandleCallback must not change the client_id
-	// presented at the exchange.
+	// RFC 6749 §4.1.3 / RFC 7636 §4.5 authorization-code exchange.
+	// When PKCE was used (CodeVerifier is non-empty), present the stored
+	// verifier. When PKCE was disabled (CodeVerifier is empty), omit
+	// code_verifier entirely — the provider authenticates the exchange via
+	// client_secret instead.
 	form := url.Values{}
 	form.Set("grant_type", grantTypeAuthorizationCode)
 	form.Set("code", code)
-	form.Set("code_verifier", ps.CodeVerifier)
+	if ps.CodeVerifier != "" {
+		form.Set("code_verifier", ps.CodeVerifier)
+	}
 	form.Set("redirect_uri", ps.RedirectURI)
 
 	// Attach client authentication. A confidential client must present its

--- a/oauth/authorization.go
+++ b/oauth/authorization.go
@@ -311,6 +311,16 @@ func handleCallback(ctx context.Context, do httpDoFunc, servers serverCache, pen
 		form.Set("client_id", ps.ClientID)
 	}
 
+	// Defence-in-depth: when PKCE is disabled, the token exchange MUST have
+	// client_secret — it is the only proof of client identity. Fail fast if
+	// neither PKCE verifier nor client_secret is available (e.g., public client
+	// used with DisablePKCE, or confidential client lookup failed mid-flow).
+	if ps.CodeVerifier == "" && form.Get("client_secret") == "" {
+		return nil, errors.Wrap(errors.InvalidArgument,
+			"oauth: DisablePKCE is set but no client_secret is available for client "+
+				ps.ClientRef+"; a confidential client is required when PKCE is not used")
+	}
+
 	var tr tokenResponse
 	raw, err := postForm(ctx, do, server.TokenEndpoint, form, &tr)
 	if err != nil {

--- a/oauth/types.go
+++ b/oauth/types.go
@@ -177,8 +177,8 @@ type PendingAuthState struct {
 	// ClientRef "".
 	ClientRef    string    `bson:"clientRef,omitempty"`
 	AccountID    string    `bson:"accountId"`
-	ClientID     string    `bson:"clientId"`     // client that initiated the flow
-	CodeVerifier string    `bson:"codeVerifier"` // encrypted at rest
+	ClientID     string    `bson:"clientId"` // client that initiated the flow
+	CodeVerifier string    `bson:"codeVerifier"`          // encrypted at rest; empty when PKCE is disabled
 	RedirectURI  string    `bson:"redirectUri"`
 	Scopes       []string  `bson:"scopes,omitempty"`
 	CreatedAt    time.Time `bson:"createdAt"` // TTL index field (10 min)
@@ -325,6 +325,14 @@ type AuthorizeOptions struct {
 	RedirectURI string            // defaults to OAuthConfig.RedirectURI
 	Scopes      []string          // defaults to OAuthConfig.Scopes
 	ExtraParams map[string]string // e.g. {"resource": "https://mcp.vercel.com"}
+
+	// DisablePKCE, when true, skips PKCE code challenge generation in the
+	// authorization request and omits the code_verifier from the token
+	// exchange. This is required for providers (e.g., Meta with System User
+	// access token type) that reject the code_challenge parameter outright.
+	// When PKCE is disabled, the provider must support client_secret-based
+	// authentication at the token endpoint instead.
+	DisablePKCE bool
 }
 
 // AuthorizationParams are the tokenized authorization request parameters
@@ -336,8 +344,8 @@ type AuthorizationParams struct {
 	ResponseType        string            // "code"
 	Scope               string            // space-delimited
 	State               string            // CSRF state (library-generated)
-	CodeChallenge       string            // PKCE (library-generated)
-	CodeChallengeMethod string            // "S256"
+	CodeChallenge       string            // PKCE (library-generated); empty when PKCE is disabled
+	CodeChallengeMethod string            // "S256"; empty when PKCE is disabled
 	ExtraParams         map[string]string // consumer-provided extras
 }
 


### PR DESCRIPTION
## Summary

Adds a per-flow `DisablePKCE` option to `AuthorizeOptions` so consumers can opt out of PKCE for providers that reject the `code_challenge` parameter (e.g., Meta's System User access token type for WhatsApp Business).

### Changes

- **`oauth/types.go`** — Added `DisablePKCE bool` field to `AuthorizeOptions` with documentation. Updated `PendingAuthState.CodeVerifier` comment to note it may be empty when PKCE is disabled. Updated `AuthorizationParams.CodeChallenge`/`CodeChallengeMethod` comments accordingly.
- **`oauth/authorization.go`** — `authorizationURL()`: conditionally generates PKCE verifier/challenge only when `DisablePKCE` is false. When disabled, `CodeVerifier` is stored as empty string on `PendingAuthState`, and `CodeChallenge`/`CodeChallengeMethod` are empty in returned params. `handleCallback()`: conditionally includes `code_verifier` in token exchange form only when `ps.CodeVerifier != ""` — when empty (PKCE disabled), the provider authenticates via `client_secret` instead.

### How it works

1. Consumer sets `AuthorizeOptions{DisablePKCE: true}` when calling `AuthorizationURL`
2. The library skips verifier generation, leaves `CodeChallenge`/`CodeChallengeMethod` empty in `AuthorizationParams`
3. `PendingAuthState` stores empty `CodeVerifier` (no schema change needed — it's already a string)
4. On callback, `handleCallback` sees empty `CodeVerifier` and omits `code_verifier` from the token exchange POST
5. The provider uses `client_secret` authentication instead (attached via `attachClientAuth`)

### Backward compatibility

- Zero value of `DisablePKCE` is `false` — all existing flows continue to use PKCE by default
- No schema change — `CodeVerifier` empty string is a valid "not set" state
- No changes to existing tests or behavior for the default PKCE-enabled path

### Context

Meta's System User access token type (used for WhatsApp Business Embedded Signup) explicitly rejects the `code_challenge` parameter with: *"Configurations using the System User access token type do not support the Proof Key for Code Exchange (PKCE) protocol."* This is a prerequisite for the OCM connector metadata proposal in `agentic-core/research`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an option to disable PKCE during OAuth sign-in for providers that don’t support it.
  * Authorization requests now automatically include PKCE parameters when enabled, and omit them when disabled.
  * Token exchange now skips sending a code verifier when PKCE was not used.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->